### PR TITLE
feat: Add default selector for container elements

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/representation/ContainerMethod.java
+++ b/utam-compiler/src/main/java/utam/compiler/representation/ContainerMethod.java
@@ -7,14 +7,10 @@ import utam.core.declarative.representation.TypeProvider;
 import utam.compiler.helpers.ElementContext;
 import utam.compiler.helpers.ParameterUtils;
 import utam.compiler.helpers.TypeUtilities;
-import utam.core.framework.base.PageObject;
-import utam.core.framework.base.ContainerElementPageObject;
 import utam.core.selenium.element.Selector;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static utam.compiler.helpers.TypeUtilities.LIST_IMPORT;
 import static utam.compiler.helpers.TypeUtilities.PAGE_OBJECT;
@@ -24,114 +20,87 @@ import static utam.compiler.translator.TranslationUtilities.getElementGetterMeth
 
 /**
  * method generated for container element
+ *
  * @author elizaveta.ivanova
  * @since 230
  */
 public abstract class ContainerMethod implements PageObjectMethod {
 
-    public static final TypeProvider RETURNS_LIST =
-        new TypeUtilities.FromString(
-            String.format("<T extends %s> List<T>", PAGE_OBJECT.getSimpleName()));
-    static final String PAGE_OBJECT_TYPE_PARAMETER_NAME = "pageObjectType";
-    static final String INJECTED_SELECTOR_PARAMETER_NAME = "injectedSelector";
-    static final TypeProvider RETURNS =
-        new TypeUtilities.FromString(String.format("<T extends %s> T", PAGE_OBJECT.getSimpleName()));
-    static final MethodParameter PAGE_OBJECT_PARAMETER =
-        new ParameterUtils.Regular(
-            PAGE_OBJECT_TYPE_PARAMETER_NAME, new TypeUtilities.FromString("Class<T>"));
-    private static final TypeProvider SELECTOR_IMPORT = new TypeUtilities.FromClass(Selector.class);
-    static final MethodParameter SELECTOR_PARAMETER =
-        new ParameterUtils.Regular(INJECTED_SELECTOR_PARAMETER_NAME, SELECTOR_IMPORT);
-    final List<TypeProvider> classImports = new ArrayList<>();
-    final List<TypeProvider> interfaceImports = new ArrayList<>();
-    final List<String> implCodeLines = new ArrayList<>();
-    final List<MethodParameter> methodParameters = new ArrayList<>();
-    final String containerElement;
-    private final TypeProvider returnType;
-    private final String methodName;
+  public static final TypeProvider RETURNS_LIST = new TypeUtilities.FromString(
+      String.format("<T extends %s> List<T>", PAGE_OBJECT.getSimpleName()));
+  static final String PAGE_OBJECT_TYPE_PARAMETER_NAME = "pageObjectType";
+  static final TypeProvider RETURNS =
+      new TypeUtilities.FromString(String.format("<T extends %s> T", PAGE_OBJECT.getSimpleName()));
+  static final MethodParameter PAGE_OBJECT_PARAMETER =
+      new ParameterUtils.Regular(PAGE_OBJECT_TYPE_PARAMETER_NAME,
+          new TypeUtilities.FromString("Class<T>"));
+  private static final TypeProvider SELECTOR_IMPORT = new TypeUtilities.FromClass(Selector.class);
+  final List<TypeProvider> classImports = new ArrayList<>();
+  final List<TypeProvider> interfaceImports = new ArrayList<>();
+  final List<String> implCodeLines = new ArrayList<>();
+  final List<MethodParameter> methodParameters = new ArrayList<>();
+  final String containerElement;
+  private final TypeProvider returnType;
+  private final String methodName;
 
-    ContainerMethod(
-        ElementContext scopeElement,
-        boolean isExpandScope,
-        String elementName,
-        TypeProvider returnType) {
-        this.returnType = returnType;
-        this.methodName = getElementGetterMethodName(elementName, true);
-        this.methodParameters.addAll(scopeElement.getParameters());
-        this.containerElement =
-            String.format(
-                "this.inContainer(%s, %s)", getElementGetterString(scopeElement), isExpandScope);
+  ContainerMethod(ElementContext scopeElement, boolean isExpandScope, String elementName,
+      TypeProvider returnType) {
+    this.returnType = returnType;
+    this.methodName = getElementGetterMethodName(elementName, true);
+    this.methodParameters.addAll(scopeElement.getParameters());
+    this.containerElement = String
+        .format("this.inContainer(%s, %s)", getElementGetterString(scopeElement), isExpandScope);
+  }
+
+  @Override public MethodDeclaration getDeclaration() {
+    return new MethodDeclarationImpl(methodName, methodParameters, returnType, interfaceImports);
+  }
+
+  @Override public List<String> getCodeLines() {
+    return implCodeLines;
+  }
+
+  @Override public List<TypeProvider> getClassImports() {
+    return classImports;
+  }
+
+  @Override public boolean isPublic() {
+    return true;
+  }
+
+  public static class WithSelectorReturnsList extends ContainerMethod {
+
+    public WithSelectorReturnsList(ElementContext scopeElement, boolean isExpandScope,
+        String elementName, Selector injectSelector, List<MethodParameter> selectorParameters) {
+      super(scopeElement, isExpandScope, elementName, RETURNS_LIST);
+      interfaceImports.add(PAGE_OBJECT);
+      interfaceImports.add(LIST_IMPORT);
+      classImports.addAll(interfaceImports);
+      // because method that build selector uses Selector.Type
+      classImports.add(SELECTOR_IMPORT);
+      methodParameters.addAll(selectorParameters);
+      methodParameters.add(PAGE_OBJECT_PARAMETER);
+      String selectorValue = buildSelectorString(injectSelector, selectorParameters);
+      implCodeLines.add(String.format("%s.loadList(%s, by(%s, Selector.Type.%s))", containerElement,
+          PAGE_OBJECT_TYPE_PARAMETER_NAME, selectorValue, injectSelector.getType()));
     }
 
-    @Override
-    public MethodDeclaration getDeclaration() {
-        return new MethodDeclarationImpl(methodName, methodParameters, returnType, interfaceImports);
+  }
+
+  public static class WithSelector extends ContainerMethod {
+
+    public WithSelector(ElementContext scopeElement, boolean isExpandScope, String elementName,
+        Selector injectSelector, List<MethodParameter> selectorParameters) {
+      super(scopeElement, isExpandScope, elementName, RETURNS);
+      interfaceImports.add(PAGE_OBJECT);
+      classImports.addAll(interfaceImports);
+      // because method that build selector uses Selector.Type
+      classImports.add(SELECTOR_IMPORT);
+      String selectorValue = buildSelectorString(injectSelector, selectorParameters);
+      implCodeLines.add(String.format("%s.load(%s, by(%s, Selector.Type.%s))", containerElement,
+          PAGE_OBJECT_TYPE_PARAMETER_NAME, selectorValue, injectSelector.getType()));
+      methodParameters.addAll(selectorParameters);
+      methodParameters.add(PAGE_OBJECT_PARAMETER);
     }
-
-    @Override
-    public List<String> getCodeLines() {
-        return implCodeLines;
-    }
-
-    @Override
-    public List<TypeProvider> getClassImports() {
-        return classImports;
-    }
-
-    @Override
-    public boolean isPublic() {
-        return true;
-    }
-
-    public static class WithSelectorReturnsList extends ContainerMethod {
-
-        public WithSelectorReturnsList(ElementContext scopeElement, boolean isExpandScope,
-            String elementName, Selector injectSelector, List<MethodParameter> selectorParameters) {
-            super(scopeElement, isExpandScope, elementName, RETURNS_LIST);
-            interfaceImports.add(PAGE_OBJECT);
-            interfaceImports.add(LIST_IMPORT);
-            classImports.addAll(interfaceImports);
-            // because method that build selector uses Selector.Type
-            classImports.add(SELECTOR_IMPORT);
-            methodParameters.addAll(selectorParameters);
-            methodParameters.add(PAGE_OBJECT_PARAMETER);
-            String selectorValue = buildSelectorString(injectSelector, selectorParameters);
-            implCodeLines.add(String
-                .format("%s.loadList(%s, by(%s, Selector.Type.%s))", containerElement,
-                    PAGE_OBJECT_TYPE_PARAMETER_NAME, selectorValue, injectSelector.getType()));
-        }
-
-    }
-
-    public static class WithSelector extends ContainerMethod {
-        public WithSelector(ElementContext scopeElement, boolean isExpandScope, String elementName,
-            Selector injectSelector, List<MethodParameter> selectorParameters) {
-            super(scopeElement, isExpandScope, elementName, RETURNS);
-            interfaceImports.add(PAGE_OBJECT);
-            classImports.addAll(interfaceImports);
-            // because method that build selector uses Selector.Type
-            classImports.add(SELECTOR_IMPORT);
-            String selectorValue = buildSelectorString(injectSelector, selectorParameters);
-            implCodeLines.add(String
-                .format("%s.load(%s, by(%s, Selector.Type.%s))", containerElement,
-                    PAGE_OBJECT_TYPE_PARAMETER_NAME, selectorValue, injectSelector.getType()));
-            methodParameters.addAll(selectorParameters);
-            methodParameters.add(PAGE_OBJECT_PARAMETER);
-        }
-    }
-
-    public static class ReturnsSingle extends ContainerMethod {
-
-        public ReturnsSingle(ElementContext scopeElement, boolean isExpandScope, String elementName) {
-            super(scopeElement, isExpandScope, elementName, RETURNS);
-            interfaceImports.add(PAGE_OBJECT);
-            interfaceImports.add(SELECTOR_IMPORT);
-            classImports.addAll(interfaceImports);
-            methodParameters.add(PAGE_OBJECT_PARAMETER);
-            methodParameters.add(SELECTOR_PARAMETER);
-            implCodeLines.add(String
-                .format("%s.load(%s, %s)", containerElement, PAGE_OBJECT_TYPE_PARAMETER_NAME,
-                    INJECTED_SELECTOR_PARAMETER_NAME));
-        }
-    }
+  }
 }

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamElement_ContainerTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamElement_ContainerTests.java
@@ -5,21 +5,17 @@ import utam.compiler.helpers.TranslationContext;
 import utam.compiler.representation.ContainerMethod;
 import utam.compiler.representation.PageObjectValidationTestHelper;
 import utam.core.declarative.representation.PageObjectMethod;
-import utam.core.framework.consumer.ContainerElement;
 import utam.core.framework.consumer.UtamError;
 import org.testng.annotations.Test;
 
-import static utam.compiler.grammar.TestUtilities.getTestTranslationContext;
 import static utam.compiler.grammar.UtamElement.ERR_CONTAINER_SHOULD_BE_PUBLIC;
 import static utam.compiler.grammar.UtamElement.Type;
 import static utam.compiler.grammar.UtamSelector_Tests.getUtamCssSelector;
 import static utam.compiler.representation.ContainerMethodTests.FIRST_CONTAINER_PARAMETER;
-import static utam.compiler.representation.ContainerMethodTests.SECOND_CONTAINER_PARAMETER;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.expectThrows;
 
 /**
@@ -28,8 +24,6 @@ import static org.testng.Assert.expectThrows;
  */
 public class UtamElement_ContainerTests {
 
-  private static final String CONTAINER_TYPE_NAME = ContainerElement.class.getSimpleName();
-  private static final String METHOD_NAME = "getTest";
   private static final String ELEMENT_NAME = "test";
 
   private static UtamElement getPublicContainerElement() {
@@ -39,28 +33,12 @@ public class UtamElement_ContainerTests {
     return utamElement;
   }
 
-  private static PageObjectMethod getElementMethod(UtamElement element) {
-    TranslationContext context = getTestTranslationContext();
-    UtamElement.Traversal abstraction = getElementAbstraction(element);
-    return abstraction.testRootTraverseComponentOrContainer(context).getElementMethod();
-  }
-
-  private static UtamElement.Traversal getElementAbstraction() {
-    return getElementAbstraction(getPublicContainerElement());
-  }
-
-  static UtamElement.Traversal getElementAbstraction(UtamElement element) {
-    UtamElement.Traversal res = element.getAbstraction();
-    assertThat(res, is(instanceOf(UtamElement.Container.class)));
-    return res;
-  }
-
   @Test
   public void testPrivateContainer() {
     UtamElement element = getPublicContainerElement();
     element.selector = getUtamCssSelector();
     element.isPublic = false;
-    UtamError e = expectThrows(UtamError.class, () -> getElementAbstraction(element));
+    UtamError e = expectThrows(UtamError.class, element::getAbstraction);
     assertThat(
         e.getMessage(), is(equalTo(String.format(ERR_CONTAINER_SHOULD_BE_PUBLIC, ELEMENT_NAME))));
   }
@@ -69,7 +47,7 @@ public class UtamElement_ContainerTests {
   public void testNotAllowedFilter() {
     UtamElement element = getPublicContainerElement();
     element.filter = UtamElementFilter_Tests.getInnerTextFilter();
-    UtamError e = expectThrows(UtamError.class, () -> getElementAbstraction(element));
+    UtamError e = expectThrows(UtamError.class, element::getAbstraction);
     assertThat(e.getMessage(), is(equalTo(element.getSupportedPropertiesErr(Type.CONTAINER))));
   }
 
@@ -77,7 +55,7 @@ public class UtamElement_ContainerTests {
   public void testNotAllowedShadow() {
     UtamElement element = getPublicContainerElement();
     element.shadow = new UtamShadowElement(new UtamElement[] {});
-    UtamError e = expectThrows(UtamError.class, () -> getElementAbstraction(element));
+    UtamError e = expectThrows(UtamError.class, element::getAbstraction);
     assertThat(e.getMessage(), is(equalTo(element.getSupportedPropertiesErr(Type.CONTAINER))));
   }
 
@@ -85,7 +63,7 @@ public class UtamElement_ContainerTests {
   public void testNotAllowedNestedElements() {
     UtamElement element = getPublicContainerElement();
     element.elements = new UtamElement[] {};
-    UtamError e = expectThrows(UtamError.class, () -> getElementAbstraction(element));
+    UtamError e = expectThrows(UtamError.class, element::getAbstraction);
     assertThat(e.getMessage(), is(equalTo(element.getSupportedPropertiesErr(Type.CONTAINER))));
   }
 
@@ -93,7 +71,7 @@ public class UtamElement_ContainerTests {
   public void testNotAllowedExternal() {
     UtamElement element = getPublicContainerElement();
     element.isExternal = true;
-    UtamError e = expectThrows(UtamError.class, () -> getElementAbstraction(element));
+    UtamError e = expectThrows(UtamError.class, element::getAbstraction);
     assertThat(e.getMessage(), is(equalTo(element.getSupportedPropertiesErr(Type.CONTAINER))));
   }
 
@@ -101,16 +79,34 @@ public class UtamElement_ContainerTests {
   public void testNotAllowedLoad() {
     UtamElement element = getPublicContainerElement();
     element.isNullable = false;
-    UtamError e = expectThrows(UtamError.class, () -> getElementAbstraction(element));
+    UtamError e = expectThrows(UtamError.class, element::getAbstraction);
     assertThat(e.getMessage(), is(equalTo(element.getSupportedPropertiesErr(Type.CONTAINER))));
+  }
+
+  @Test
+  public void testPublicAbstraction() {
+    UtamElement element = getPublicContainerElement();
+    assertThat(element.getAbstraction(), is(instanceOf(UtamElement.Container.class)));
+    assertThat(
+        element.selector.getSelector().getValue(),
+        is(equalTo(UtamElement.Container.DEFAULT_CONTAINER_SELECTOR_CSS)));
   }
 
   /** The getDeclaredMethod method should return null for a non-public container */
   @Test
-  public void testGetDeclaredMethodWithNonPublicComponent() {
-    UtamElement element = getPublicContainerElement();
-    element.isPublic = false;
-    assertThrows(() -> getElementMethod(element));
+  public void testGetDeclaredMethodWithNoSelector() {
+    TranslationContext context = new DeserializerUtilities().getContext("containerElement");
+    ElementContext element = context.getElement("containerInsideRoot");
+    PageObjectMethod method = element.getElementMethod();
+    assertThat(element.getType().getSimpleName(), is(equalTo("ContainerElement")));
+    PageObjectValidationTestHelper.MethodInfo expectedMethod =
+        new PageObjectValidationTestHelper.MethodInfo(
+            "getContainerInsideRoot", "<T extends PageObject> T");
+    expectedMethod.addParameter(FIRST_CONTAINER_PARAMETER);
+    expectedMethod.addCodeLines(
+        "this.inContainer(this.getRootElement(), true)"
+            + ".load(pageObjectType, by(\":scope > *:first-child\", Selector.Type.CSS))");
+    PageObjectValidationTestHelper.validateMethod(method, expectedMethod);
   }
 
   /** The getDeclaredMethods method should return the proper value for a container */
@@ -127,10 +123,10 @@ public class UtamElement_ContainerTests {
     expectedMethod.addParameter(
         new PageObjectValidationTestHelper.MethodParameterInfo("scopeArg", "String"));
     expectedMethod.addParameter(FIRST_CONTAINER_PARAMETER);
-    expectedMethod.addParameter(SECOND_CONTAINER_PARAMETER);
 
     expectedMethod.addCodeLines(
-        "this.inContainer(this.getScopeElement(scopeArg), true).load(pageObjectType, injectedSelector)");
+        "this.inContainer(this.getScopeElement(scopeArg), true)"
+            + ".load(pageObjectType, by(\":scope > *:first-child\", Selector.Type.CSS))");
     PageObjectValidationTestHelper.validateMethod(method, expectedMethod);
   }
 

--- a/utam-compiler/src/test/java/utam/compiler/representation/ContainerMethodTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/representation/ContainerMethodTests.java
@@ -1,24 +1,21 @@
 package utam.compiler.representation;
 
 import utam.core.declarative.representation.MethodDeclaration;
-import utam.core.declarative.representation.MethodParameter;
 import utam.compiler.helpers.ElementContext;
-import utam.compiler.helpers.ParameterUtils;
-import utam.compiler.helpers.PrimitiveType;
 import utam.compiler.representation.PageObjectValidationTestHelper.MethodInfo;
 import utam.compiler.representation.PageObjectValidationTestHelper.MethodParameterInfo;
 import utam.core.declarative.representation.PageObjectMethod;
 import utam.core.framework.base.PageObject;
 import org.testng.annotations.Test;
 import utam.core.selenium.element.Selector;
+import utam.core.selenium.element.Web;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static utam.compiler.grammar.TestUtilities.getCssSelector;
+import static utam.compiler.helpers.ParameterUtils.EMPTY_PARAMETERS;
 import static utam.compiler.helpers.TypeUtilities.Element.actionable;
 import static utam.compiler.representation.ContainerMethod.*;
 
@@ -30,14 +27,12 @@ import static utam.compiler.representation.ContainerMethod.*;
  */
 public class ContainerMethodTests {
 
-  public static final String RETURN_TYPE = RETURNS.getSimpleName();;
+  public static final String RETURN_TYPE = RETURNS.getSimpleName();
+  public static final String LIST_RETURN_TYPE = RETURNS_LIST.getSimpleName();
   public static final String EXPECTED_CODE_LOAD = "load(pageObjectType, injectedSelector)";
   public static final MethodParameterInfo FIRST_CONTAINER_PARAMETER =
       new PageObjectValidationTestHelper.MethodParameterInfo(
           PAGE_OBJECT_PARAMETER.getValue(), PAGE_OBJECT_PARAMETER.getType().getSimpleName());
-  public static final MethodParameterInfo SECOND_CONTAINER_PARAMETER =
-      new PageObjectValidationTestHelper.MethodParameterInfo(
-          SELECTOR_PARAMETER.getValue(), SELECTOR_PARAMETER.getType().getSimpleName());
   private static final String METHOD_NAME = "getContainer";
   private static final String ELEMENT_NAME = "container";
 
@@ -53,15 +48,28 @@ public class ContainerMethodTests {
   }
 
   @Test
-  public void testContainerMethodReturnsSingle() {
+  public void testContainerMethodWithSelector() {
     MethodInfo info = new MethodInfo(METHOD_NAME, RETURN_TYPE);
     info.addCodeLine(
-        "this.inContainer(this.getScope(), false).load(pageObjectType, injectedSelector)");
-    info.addImportedTypes(PageObject.class.getName(), Selector.class.getName());
+        "this.inContainer(this.getScope(), false).load(pageObjectType, by(\".fakeSelector\", Selector.Type.CSS))");
+    info.addImportedTypes(PageObject.class.getName());
     info.addImpliedImportedTypes(PageObject.class.getName(), Selector.class.getName());
     info.addParameter(FIRST_CONTAINER_PARAMETER);
-    info.addParameter(SECOND_CONTAINER_PARAMETER);
-    ContainerMethod method = new ContainerMethod.ReturnsSingle(getScope(), false, ELEMENT_NAME);
+    ContainerMethod method = new ContainerMethod.WithSelector(
+        getScope(), false, ELEMENT_NAME, Web.byCss(".fakeSelector"), EMPTY_PARAMETERS);
+    PageObjectValidationTestHelper.validateMethod(method, info);
+  }
+
+  @Test
+  public void testContainerMethodWithSelectorReturnsList() {
+    MethodInfo info = new MethodInfo(METHOD_NAME, LIST_RETURN_TYPE);
+    info.addCodeLine(
+        "this.inContainer(this.getScope(), false).loadList(pageObjectType, by(\".fakeSelector\", Selector.Type.CSS))");
+    info.addImportedTypes(PageObject.class.getName(), List.class.getName());
+    info.addImpliedImportedTypes(PageObject.class.getName(), Selector.class.getName());
+    info.addParameter(FIRST_CONTAINER_PARAMETER);
+    ContainerMethod method = new ContainerMethod.WithSelectorReturnsList(
+        getScope(), false, ELEMENT_NAME, Web.byCss(".fakeSelector"), EMPTY_PARAMETERS);
     PageObjectValidationTestHelper.validateMethod(method, info);
   }
 }


### PR DESCRIPTION
Container elements that do not have a declared selector should have a default
selector implicitly added. This default selector will be `:scope > *:first-child`.