### PR TITLE
Add ability to specify profile values in Java properties file

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/translator/TranslatorGenerationCommand.java
+++ b/utam-compiler/src/main/java/utam/compiler/translator/TranslatorGenerationCommand.java
@@ -23,17 +23,21 @@ public class TranslatorGenerationCommand implements Callable<Integer> {
   private static final String INVALID_UNIT_TEST_CONFIG =
       "You cannot specify a unit test runner without a destination directory for unit tests";
 
-  @Option(names = {"-d", "-destinationDirectory", "--destinationDirectory"}, required = true,
-          description = "Destination directory to which generated Page Object files will be written.")
-  private File destinationDirectory;
+  @Option(names = {"-o", "-outputDirectory", "--outputDirectory"}, required = true,
+          description = "Output directory to which generated Page Object files will be written.")
+  private File outputDirectory;
+
+  @Option(names = {"-p", "-profileDirectory", "--profileDirectory"}, required = true,
+      description = "Destination directory to which profile information will be written.")
+  private File profileDirectory;
 
   @Option(names = {"-m", "-packageMappingFile", "--packageMappingFile"}, required = true,
           description = "File containing mapping between directories and package names.")
   private File packageMappingFile;
 
-  @Option(names = {"-p", "-profileDirectory", "--profileDirectory"}, required = true,
-          description = "Destination directory to which profile information will be written.")
-  private File profileDirectory;
+  @Option(names = {"-d", "-profileDefinitionsFile", "--profileDefinitionsFile"},
+          description = "File containing definitions of profile names and their valid values.")
+  private File profileDefinitionsFile;
 
   @Option(names = {"-r", "-unitTestRunner", "--unitTestRunner"}, defaultValue = "NONE",
           description = "Unit test runner to use for generated unit tests for Page Objects. Valid values: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE})")
@@ -44,10 +48,10 @@ public class TranslatorGenerationCommand implements Callable<Integer> {
   private File unitTestDirectory;
 
   @Option(names = {"-i", "-inputDirectory", "--inputDirectory"},
-          description = "Input directory to be recursively scanned for utam.core.declarative Page Object description files. Cannot be used with an explicit file list.")
+          description = "Input directory to be recursively scanned for UTAM declarative Page Object description files. Cannot be used with an explicit file list.")
   private File inputDirectory;
 
-  @Parameters(description = "Explicit list of utam.core.declarative Page Object description files to generate. Cannot be used with the --inputDirectory option.")
+  @Parameters(description = "Explicit list of UTAM declarative Page Object description files to generate. Cannot be used with the --inputDirectory option.")
   private List<File> inputFiles;
 
   private Exception thrownError;
@@ -82,27 +86,32 @@ public class TranslatorGenerationCommand implements Callable<Integer> {
         unitTestDirectoryPath = unitTestDirectory.toString();
       }
 
+      String profileDefinitionsFilePath = "";
+      if (profileDefinitionsFile != null) {
+        profileDefinitionsFilePath = profileDefinitionsFile.toString();
+      }
+
       TranslatorRunner translator;
       if (inputFiles != null && inputFiles.size() > 0) {
         translator = new DefaultTranslatorRunner(
             new DefaultTranslatorConfiguration(
                 inputFiles,
-                destinationDirectory.toString(),
+                outputDirectory.toString(),
                 unitTestDirectoryPath,
                 testRunner.toString(),
-                packageMappingFile.toString(),
+                DefaultTranslatorConfiguration.createPackageMap(packageMappingFile.toString()),
                 profileDirectory.toString(),
-                new HashMap<>()));
+                DefaultTranslatorConfiguration.createProfileMap(profileDefinitionsFilePath)));
       } else {
         translator = new DefaultTranslatorRunner(
             new DefaultTranslatorConfiguration(
                 inputDirectory.toString(),
-                destinationDirectory.toString(),
+                outputDirectory.toString(),
                 unitTestDirectoryPath,
                 testRunner.toString(),
-                packageMappingFile.toString(),
+                DefaultTranslatorConfiguration.createPackageMap(packageMappingFile.toString()),
                 profileDirectory.toString(),
-                new HashMap<>()));
+                DefaultTranslatorConfiguration.createProfileMap(profileDefinitionsFilePath)));
       }
       translator.run();
       translator.write();


### PR DESCRIPTION
The format for properties is `name=value1,value2,...,valueN` where `name`
is the name of the profile and the values is a comma-delimited list of valid
values for the profile. Note that this implies profile values cannot contain
a comma. The profiles file can be specified on the command line in the
standalone compiler with the `--profileDefinitionsFile` (short option: `-d`)
flag.

This also cleans up the (now-)unneeded constructors in the
`DefaultTranslatorConfiguration` class. It also changes the command-line
argument for the output of generated Page Objects to `--outputDirectory`,
from `--destinationDirectory`, with a short name of `-o`.