### PR TITLE
@W-9062684 fix for classloader in core

### DIFF
--- a/utam-core/src/main/java/utam/core/framework/context/DefaultProfileContext.java
+++ b/utam-core/src/main/java/utam/core/framework/context/DefaultProfileContext.java
@@ -46,7 +46,7 @@ public final class DefaultProfileContext implements ProfileContext {
   }
 
   private Properties getBeansFromResource() {
-    ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+    ClassLoader classLoader = getClass().getClassLoader();
     String configName = profile.getConfigName() + ".properties";
     Properties properties = new Properties();
     try {


### PR DESCRIPTION
ClassLoader.getSystemClassLoader() does not load resources properly in core, no idea why, so changing to using current class.
Result of the issue was that mobile configs were not loaded properly