### PR TITLE
(@W-9142906)add support to sent change event from document

### DIFF
--- a/utam-core/src/main/java/utam/core/driver/Document.java
+++ b/utam-core/src/main/java/utam/core/driver/Document.java
@@ -36,4 +36,12 @@ public interface Document {
    * @return true if element found
    */
   boolean containsElement(Locator locator);
+  
+  /**
+   * Trigger the onChange event for the element with the given locator 
+   * in the dom, since appium doesn't use the native keyboard
+   * 
+   * @param locator locator to find an element
+   */
+  void triggerChangeEvent(Locator locator);
 }

--- a/utam-core/src/main/java/utam/core/framework/element/DocumentObject.java
+++ b/utam-core/src/main/java/utam/core/framework/element/DocumentObject.java
@@ -8,9 +8,14 @@
 package utam.core.framework.element;
 
 import java.time.Duration;
+import java.util.List;
+
+import org.openqa.selenium.WebElement;
+
 import utam.core.driver.Document;
 import utam.core.driver.Driver;
 import utam.core.driver.Expectations;
+import utam.core.element.Element;
 import utam.core.element.FindContext.Type;
 import utam.core.element.Locator;
 import utam.core.framework.base.PageObjectsFactory;
@@ -24,6 +29,14 @@ import utam.core.framework.base.PageObjectsFactory;
 public class DocumentObject implements Document {
 
   static final String DOM_READY_JAVASCRIPT = "document.readyState === 'complete'";
+  static final String ONCHANGE_JAVASCRIPT = 
+          "if ('createEvent in document') {" +
+          "   var evt = document.createEvent('HTMLEvents');" +
+          "   evt.initEvent('change', false, true);" +
+          "   arguments[0].dispatchEvent(evt);" +
+          "} else {" +
+          "   arguments[0].fireEvent('onchange')" +
+          "}";
 
   private static final Expectations<Boolean> isDOMReady =
       new ExpectationsImpl<>("wait for document ready state", driver ->
@@ -52,5 +65,11 @@ public class DocumentObject implements Document {
   @Override
   public boolean containsElement(Locator locator) {
     return driver.findElements(locator, Type.NULLABLE).size() > 0;
+  }
+  
+  @Override
+  public void triggerChangeEvent(Locator locator) {
+      List<Element> elements = driver.findElements(locator, Type.NULLABLE);
+      driver.executeScript(ONCHANGE_JAVASCRIPT, elements.get(0));
   }
 }

--- a/utam-core/src/test/java/utam/core/framework/element/DocumentObjectTests.java
+++ b/utam-core/src/test/java/utam/core/framework/element/DocumentObjectTests.java
@@ -14,11 +14,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.List;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.testng.annotations.Test;
 import utam.core.MockUtilities;
 import utam.core.driver.Document;
+import utam.core.element.Element;
 import utam.core.selenium.element.LocatorBy;
 
 /**
@@ -54,5 +57,16 @@ public class DocumentObjectTests {
         .thenReturn(Collections.singletonList(mock(WebElement.class)));
     assertThat(document.containsElement(LocatorBy.byCss("existing")), is(true));
     assertThat(document.containsElement(LocatorBy.byCss("non-existing")), is(false));
+  }
+
+  @Test
+  public void testTriggerChangeEvent() {
+    String testLocatorString = "existing";
+    MockUtilities mock = new MockUtilities();
+    when(mock.getWebDriverMock().findElements(By.cssSelector(testLocatorString)))
+    .thenReturn(Collections.singletonList(mock(WebElement.class)));
+    when(mock.getExecutorMock().executeScript(DocumentObject.ONCHANGE_JAVASCRIPT)).thenReturn(true);
+    Document document = new DocumentObject(mock.getFactory());
+    document.triggerChangeEvent(LocatorBy.byCss(testLocatorString));
   }
 }


### PR DESCRIPTION
Without this support, on some webview page, the input value that setup via setText cannot be set to the form that submitted to server side. This is limitation is on mobile ios only. 