### PR TITLE
chore: Replace Collections.EMPTY_LIST with Collections.emptyList()

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
@@ -320,7 +320,8 @@ public final class UtamElement {
       final PageObjectMethod method;
       if (filter != null) {
         // element parameters do not include filter or matcher parameters
-        List<MethodParameter> elementParameters = new ArrayList<>(scopeElement == null? Collections.EMPTY_LIST: scopeElement.getParameters());
+        List<MethodParameter> elementParameters =  new ArrayList<>(
+            scopeElement == null ? Collections.emptyList() : scopeElement.getParameters());
         elementParameters.addAll(selectorContext.getParameters());
         method =
             new ElementMethod.Filtered(

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamSelector.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamSelector.java
@@ -184,7 +184,7 @@ public class UtamSelector {
 
     // used in tests
     public Context(Locator locator) {
-      this(locator, Collections.EMPTY_LIST);
+      this(locator, Collections.emptyList());
     }
 
     // used in tests

--- a/utam-compiler/src/main/java/utam/compiler/helpers/ClickableActionType.java
+++ b/utam-compiler/src/main/java/utam/compiler/helpers/ClickableActionType.java
@@ -52,7 +52,7 @@ public enum ClickableActionType implements ActionType {
 
   @Override
   public List<TypeProvider> getParametersTypes() {
-    return Collections.EMPTY_LIST;
+    return Collections.emptyList();
   }
 
   @Override

--- a/utam-compiler/src/main/java/utam/compiler/helpers/ElementContext.java
+++ b/utam-compiler/src/main/java/utam/compiler/helpers/ElementContext.java
@@ -303,7 +303,13 @@ public abstract class ElementContext {
     public static final ElementContext DOCUMENT_ELEMENT = new Document();
 
     private Document() {
-      super(null, DOCUMENT_ELEMENT_NAME, null, EMPTY_SELECTOR, false, Collections.EMPTY_LIST, false);
+      super(null,
+          DOCUMENT_ELEMENT_NAME,
+          null,
+          EMPTY_SELECTOR,
+          false,
+          Collections.emptyList(),
+          false);
       setElementMethod(ElementMethod.DOCUMENT_GETTER);
     }
 
@@ -323,7 +329,13 @@ public abstract class ElementContext {
     static final ElementContext SELF_ELEMENT = new Self();
 
     private Self() {
-      super(null, SELF_ELEMENT_NAME, null, EMPTY_SELECTOR, false, Collections.EMPTY_LIST, false);
+      super(null,
+          SELF_ELEMENT_NAME,
+          null,
+          EMPTY_SELECTOR,
+          false,
+          Collections.emptyList(),
+          false);
 
     }
 

--- a/utam-compiler/src/main/java/utam/compiler/helpers/MatcherType.java
+++ b/utam-compiler/src/main/java/utam/compiler/helpers/MatcherType.java
@@ -20,8 +20,8 @@ import static utam.compiler.helpers.ParameterUtils.getParametersValuesString;
  * @since 232
  */
 public enum MatcherType {
-  isTrue("%s", "return %s;", Collections.EMPTY_LIST, PrimitiveType.BOOLEAN),
-  isFalse("Boolean.FALSE.equals(%s)", "return Boolean.FALSE.equals(%s);", Collections.EMPTY_LIST, PrimitiveType.BOOLEAN),
+  isTrue("%s", "return %s;", Collections.emptyList(), PrimitiveType.BOOLEAN),
+  isFalse("Boolean.FALSE.equals(%s)", "return Boolean.FALSE.equals(%s);", Collections.emptyList(), PrimitiveType.BOOLEAN),
   stringContains("{ String tmp = %s;\nreturn tmp!= null && tmp.contains(%s); }",
       "String tmp = %s;\nreturn tmp!= null && tmp.contains(%s);",
       Collections.singletonList(PrimitiveType.STRING), PrimitiveType.STRING),

--- a/utam-compiler/src/main/java/utam/compiler/representation/ElementMethod.java
+++ b/utam-compiler/src/main/java/utam/compiler/representation/ElementMethod.java
@@ -41,7 +41,7 @@ public abstract class ElementMethod implements PageObjectMethod {
       "getDocument",
       EMPTY_PARAMETERS,
       DOCUMENT_TYPE,
-      Collections.EMPTY_LIST);
+      Collections.emptyList());
   public static final PageObjectMethod DOCUMENT_GETTER = new PageObjectMethod() {
     @Override
     public MethodDeclaration getDeclaration() {
@@ -56,7 +56,7 @@ public abstract class ElementMethod implements PageObjectMethod {
 
     @Override
     public List<TypeProvider> getClassImports() {
-      return Collections.EMPTY_LIST;
+      return Collections.emptyList();
     }
 
     @Override

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamArgument_Tests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamArgument_Tests.java
@@ -287,7 +287,7 @@ public class UtamArgument_Tests {
   @Test
   public void testGetParametersWithNullArgumentArray() {
     assertThat(
-        getArgsProcessor(null, Collections.EMPTY_LIST, ARGS_CONTEXT).getOrdered(),
+        getArgsProcessor(null, Collections.emptyList(), ARGS_CONTEXT).getOrdered(),
         is(empty()));
     assertThat(getArgsProcessor(null, ARGS_CONTEXT).getOrdered(), is(empty()));
   }
@@ -413,7 +413,7 @@ public class UtamArgument_Tests {
     UtamSelector selector = new UtamSelector(".selector[title='%s']", new UtamArgument[] {selectorArg});
     UtamArgument arg = new UtamArgument(selector);
     List<MethodParameter> parameters = UtamArgument.getArgsProcessor(
-        new UtamArgument[] {arg}, Arrays.asList(SELECTOR), ARGS_CONTEXT).getOrdered();
+        new UtamArgument[] {arg}, Collections.singletonList(SELECTOR), ARGS_CONTEXT).getOrdered();
     assertThat(parameters, hasSize(2));
     assertThat(parameters.get(0).getValue(),
         is(equalTo("LocatorBy.byCss(String.format(\".selector[title='%s']\", title))")));

--- a/utam-compiler/src/test/java/utam/compiler/helpers/MethodContextTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/helpers/MethodContextTests.java
@@ -48,7 +48,7 @@ public class MethodContextTests {
   public void testReturnList() {
     MethodContext methodContext = new MethodContext("name", STRING, true);
     assertThat(methodContext.getReturnType(null), is(instanceOf(ListOf.class)));
-    List<TypeProvider> imports = methodContext.getReturnTypeImports(Collections.EMPTY_LIST);
+    List<TypeProvider> imports = methodContext.getReturnTypeImports(Collections.emptyList());
     assertThat(imports.size(), is(2));
     assertThat(imports.get(0).isSameType(LIST_IMPORT), is(true));
     assertThat(imports.get(1).isSameType(STRING), is(true));

--- a/utam-compiler/src/test/java/utam/compiler/representation/InterfaceMethodTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/representation/InterfaceMethodTests.java
@@ -42,7 +42,7 @@ public class InterfaceMethodTests {
     MethodInfo info = new MethodInfo("testMethod", "Actionable");
     TypeProvider returnType = new TypeUtilities.FromClass(Actionable.class);
     InterfaceMethod method =
-        new InterfaceMethod(getMethodContext(returnType, false), Collections.EMPTY_LIST, "", false);
+        new InterfaceMethod(getMethodContext(returnType, false), Collections.emptyList(), "", false);
     PageObjectValidationTestHelper.validateMethod(method, info);
     assertThat(method.getClassImports(), hasSize(1));
   }
@@ -51,7 +51,7 @@ public class InterfaceMethodTests {
   public void testInterfaceMethodReturnsList() {
     TypeProvider returnType = new TypeUtilities.FromString("SomeReturnType");
     InterfaceMethod method = new InterfaceMethod(getMethodContext(returnType, true),
-        Collections.EMPTY_LIST, "", false);
+        Collections.emptyList(), "", false);
     assertThat(method.getCodeLines().isEmpty(), is(true));
     assertThat(method.getClassImports(), hasSize(2));
     assertThat(method.getClassImports().get(0).getSimpleName(), is(equalTo("List")));

--- a/utam-core/src/main/java/utam/core/declarative/representation/AnnotationProvider.java
+++ b/utam-core/src/main/java/utam/core/declarative/representation/AnnotationProvider.java
@@ -31,6 +31,6 @@ public interface AnnotationProvider {
    * @return by default empty list
    */
   default List<TypeProvider> getImportTypes() {
-    return Collections.EMPTY_LIST;
+    return Collections.emptyList();
   }
 }

--- a/utam-core/src/main/java/utam/core/framework/element/ElementLocationChain.java
+++ b/utam-core/src/main/java/utam/core/framework/element/ElementLocationChain.java
@@ -166,7 +166,7 @@ public final class ElementLocationChain implements ElementLocation {
     Instance(Element element) {
       super(null, null);
       this.elements =
-          element.isNull() ? Collections.EMPTY_LIST : Collections.singletonList(element);
+          element.isNull() ? Collections.emptyList() : Collections.singletonList(element);
     }
 
     @Override

--- a/utam-core/src/main/java/utam/core/selenium/element/ElementAdapter.java
+++ b/utam-core/src/main/java/utam/core/selenium/element/ElementAdapter.java
@@ -47,7 +47,7 @@ public class ElementAdapter implements Element {
           + "} else {"
           + "arguments[0].scrollIntoView(false);"
           + "}";
-  static final List<Element> EMPTY_LIST = Collections.EMPTY_LIST;
+  static final List<Element> EMPTY_LIST = Collections.emptyList();
   static final String CLICK_VIA_JAVASCRIPT = "arguments[0].click();";
   static final String FOCUS_VIA_JAVASCRIPT = "arguments[0].focus();";
   static final String SCROLL_CENTER_VIA_JAVASCRIPT = "arguments[0].scrollIntoView({block:'center'});";


### PR DESCRIPTION
This reduces the need to suppress unchecked assignment warnings.