### PR TITLE
ability to check presence of root Page Object

### DIFF
--- a/utam-core/src/main/java/utam/core/driver/Document.java
+++ b/utam-core/src/main/java/utam/core/driver/Document.java
@@ -8,6 +8,7 @@
 package utam.core.driver;
 
 import utam.core.element.Locator;
+import utam.core.framework.base.RootPageObject;
 
 /**
  * document object to interact with a browser
@@ -36,4 +37,12 @@ public interface Document {
    * @return true if element found
    */
   boolean containsElement(Locator locator);
+
+  /**
+   * check if there is a root page object present in the DOM
+   *
+   * @param pageObjectType
+   * @return true if Page Object's root element is found
+   */
+  boolean containsObject(Class<? extends RootPageObject> pageObjectType);
 }

--- a/utam-core/src/main/java/utam/core/framework/base/RootPageObject.java
+++ b/utam-core/src/main/java/utam/core/framework/base/RootPageObject.java
@@ -7,9 +7,8 @@
  */
 package utam.core.framework.base;
 
-import static utam.core.element.FindContext.Type.EXISTING;
-
 import utam.core.element.ElementLocation;
+import utam.core.element.FindContext;
 import utam.core.framework.consumer.UtamError;
 import utam.core.framework.element.ElementLocationChain;
 
@@ -21,12 +20,12 @@ import utam.core.framework.element.ElementLocationChain;
  */
 public interface RootPageObject extends PageObject {
 
-  default ElementLocation setRootLocator() {
+  default ElementLocation setRootLocator(FindContext findContext) {
     if (!getClass().isAnnotationPresent(PageMarker.Find.class)) {
       throw new UtamError(String.format("root selector is not set for the page object instance %s",
           getClass().getName()));
     }
     PageMarker.Find annotation = getClass().getDeclaredAnnotation(PageMarker.Find.class);
-    return new ElementLocationChain(PageMarker.getRootLocator(annotation), EXISTING);
+    return new ElementLocationChain(PageMarker.getRootLocator(annotation), findContext);
   }
 }

--- a/utam-core/src/main/java/utam/core/framework/consumer/UtamLoader.java
+++ b/utam-core/src/main/java/utam/core/framework/consumer/UtamLoader.java
@@ -7,6 +7,7 @@
  */
 package utam.core.framework.consumer;
 
+import utam.core.driver.Document;
 import utam.core.element.Locator;
 import utam.core.framework.base.PageObject;
 import utam.core.framework.base.RootPageObject;
@@ -63,4 +64,12 @@ public interface UtamLoader {
    * recreates instance of the page objects context and factory with new settings
    */
   void resetContext();
+
+  /**
+   * get instance of the Document Object to call its public methods from test, ex.
+   * loader.getDocument().containsObject(MyModal.class);
+   *
+   * @return new instance every time method is called
+   */
+  Document getDocument();
 }

--- a/utam-core/src/main/java/utam/core/framework/consumer/UtamLoaderImpl.java
+++ b/utam-core/src/main/java/utam/core/framework/consumer/UtamLoaderImpl.java
@@ -12,6 +12,7 @@ import static utam.core.selenium.factory.WebDriverFactory.getAdapter;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import utam.core.driver.Document;
 import utam.core.driver.Driver;
 import utam.core.driver.DriverTimeouts;
 import utam.core.element.Element;
@@ -21,6 +22,7 @@ import utam.core.framework.base.PageObject;
 import utam.core.framework.base.PageObjectsFactory;
 import utam.core.framework.base.PageObjectsFactoryImpl;
 import utam.core.framework.base.RootPageObject;
+import utam.core.framework.element.DocumentObject;
 import utam.core.framework.element.ElementLocationChain;
 import utam.core.selenium.appium.MobileElementAdapter;
 import utam.core.selenium.element.ElementAdapter;
@@ -76,7 +78,7 @@ public class UtamLoaderImpl implements UtamLoader {
   @Override
   public <T extends RootPageObject> T create(Class<T> type) {
     T instance = factory.getPageContext().getBean(type);
-    ElementLocation finder = instance.setRootLocator();
+    ElementLocation finder = instance.setRootLocator(EXISTING);
     factory.bootstrap(instance, finder);
     return instance;
   }
@@ -100,5 +102,10 @@ public class UtamLoaderImpl implements UtamLoader {
         .scope(locator, EXISTING);
     factory.bootstrap(instance, finder);
     return instance;
+  }
+
+  @Override
+  public Document getDocument() {
+    return new DocumentObject(factory);
   }
 }

--- a/utam-core/src/main/java/utam/core/framework/element/DocumentObject.java
+++ b/utam-core/src/main/java/utam/core/framework/element/DocumentObject.java
@@ -7,13 +7,17 @@
  */
 package utam.core.framework.element;
 
+import static utam.core.element.FindContext.Type.NULLABLE;
+
 import java.time.Duration;
 import utam.core.driver.Document;
 import utam.core.driver.Driver;
 import utam.core.driver.Expectations;
+import utam.core.element.ElementLocation;
 import utam.core.element.FindContext.Type;
 import utam.core.element.Locator;
 import utam.core.framework.base.PageObjectsFactory;
+import utam.core.framework.base.RootPageObject;
 
 /**
  * implementation of the document object
@@ -32,11 +36,13 @@ public class DocumentObject implements Document {
   private final Driver driver;
   private final Duration timeout;
   private final Duration interval;
+  private final PageObjectsFactory factory;
 
   public DocumentObject(PageObjectsFactory factory) {
     this.driver = factory.getDriver();
     this.timeout = factory.getDriverContext().getTimeouts().getWaitForTimeout();
     this.interval = factory.getDriverContext().getTimeouts().getPollingInterval();
+    this.factory = factory;
   }
 
   @Override
@@ -51,6 +57,13 @@ public class DocumentObject implements Document {
 
   @Override
   public boolean containsElement(Locator locator) {
-    return driver.findElements(locator, Type.NULLABLE).size() > 0;
+    return driver.findElements(locator, NULLABLE).size() > 0;
+  }
+
+  @Override
+  public boolean containsObject(Class<? extends RootPageObject> pageObjectType) {
+    RootPageObject instance = factory.getPageContext().getBean(pageObjectType);
+    ElementLocation finder = instance.setRootLocator(NULLABLE);
+    return !finder.findElements(driver).isEmpty();
   }
 }

--- a/utam-core/src/test/java/utam/core/framework/consumer/UtamLoaderTests.java
+++ b/utam-core/src/test/java/utam/core/framework/consumer/UtamLoaderTests.java
@@ -8,6 +8,7 @@
 package utam.core.framework.consumer;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -105,6 +106,11 @@ public class UtamLoaderTests {
     PageObjectsFactory factory = loader.getFactory();
     loader.resetContext();
     assertThat(loader.getFactory(), is(not(sameInstance(factory))));
+  }
+
+  @Test
+  public void testGetDocument() {
+    assertThat(getDefaultLoader().getDocument(), is(notNullValue()));
   }
 
   private static class ContainerMock implements Container {

--- a/utam-core/src/test/java/utam/core/framework/element/DocumentObjectTests.java
+++ b/utam-core/src/test/java/utam/core/framework/element/DocumentObjectTests.java
@@ -19,6 +19,9 @@ import org.openqa.selenium.WebElement;
 import org.testng.annotations.Test;
 import utam.core.MockUtilities;
 import utam.core.driver.Document;
+import utam.core.framework.base.BasePageObject;
+import utam.core.framework.base.PageMarker;
+import utam.core.framework.base.RootPageObject;
 import utam.core.selenium.element.LocatorBy;
 
 /**
@@ -54,5 +57,27 @@ public class DocumentObjectTests {
         .thenReturn(Collections.singletonList(mock(WebElement.class)));
     assertThat(document.containsElement(LocatorBy.byCss("existing")), is(true));
     assertThat(document.containsElement(LocatorBy.byCss("non-existing")), is(false));
+  }
+
+  @Test
+  public void testContainsObject() {
+    MockUtilities mock = new MockUtilities();
+    Document document = new DocumentObject(mock.getFactory());
+    when(mock.getWebDriverMock().findElements(By.cssSelector("found")))
+        .thenReturn(Collections.singletonList(mock(WebElement.class)));
+    assertThat(document.containsObject(TestContains.class), is(true));
+    assertThat(document.containsObject(TestNotContains.class), is(false));
+  }
+
+  @PageMarker.Find(css = "notfound")
+  static class TestNotContains extends BasePageObject implements RootPageObject {
+    // has to be public for reflection to create instance
+    public TestNotContains() {}
+  }
+
+  @PageMarker.Find(css = "found")
+  static class TestContains extends BasePageObject implements RootPageObject {
+    // has to be public for reflection to create instance
+    public TestContains() {}
   }
 }


### PR DESCRIPTION
Subject of this PR is to provide test writer ability to check presence of the root PO, for example modal.
- added public API Document.containsObject(type)
- added public API UtamLoader.getDocument()
- unit tests

from test can be used like this: `loader.getDocument().containsObject(MyRootPageObject.class)`