### PR TITLE
PO should not reference non-existing arguments in imperative extensio…

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamArgument.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamArgument.java
@@ -49,7 +49,7 @@ class UtamArgument {
   static final String ERR_NAME_TYPE_REDUNDANT = "%s: properties 'name' or 'type' are redundant";
   static final String ERR_PREDICATE_REDUNDANT = "%s: property 'predicate' is only supported for 'function' type";
   static final String ERR_REFERENCE_MISSING = "%s: A statement declares a reference to argument %s but there’s no matching method-level argument";
-  static final String ERR_ARG_TYPE_MISMATCH = "%s: A statement declares an argument %s 's type as %s, but the type does not match with the same argument at method-level";
+  static final String ERR_ARG_TYPE_MISMATCH = "%s: A statement declares an argument %s's type as %s, but the type does not match with the same argument at method-level";
 
   private static final String SUPPORTED_ARGS_TYPES =
       Stream.concat(Stream.of(FUNCTION_TYPE_PROPERTY, SELECTOR_TYPE_PROPERTY, REFERENCE_TYPE_PROPERTY),

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamArgument.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamArgument.java
@@ -48,6 +48,9 @@ class UtamArgument {
   static final String ERR_ARGS_WRONG_TYPE = "%s: expected type is '%s', actual was '%s'";
   static final String ERR_NAME_TYPE_REDUNDANT = "%s: properties 'name' or 'type' are redundant";
   static final String ERR_PREDICATE_REDUNDANT = "%s: property 'predicate' is only supported for 'function' type";
+  static final String ERR_REFERENCE_MISSING = "%s: A statement declares a reference to argument %s but there’s no matching method-level argument";
+  static final String ERR_ARG_TYPE_MISMATCH = "%s: A statement declares an argument %s 's type as %s, but the type does not match with the same argument at method-level";
+
   private static final String SUPPORTED_ARGS_TYPES =
       Stream.concat(Stream.of(FUNCTION_TYPE_PROPERTY, SELECTOR_TYPE_PROPERTY, REFERENCE_TYPE_PROPERTY),
           Stream.of(PrimitiveType.values())

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamArgumentDeserializer.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamArgumentDeserializer.java
@@ -61,8 +61,8 @@ class UtamArgumentDeserializer extends
             String.format(
                 ERR_ARG_TYPE_MISMATCH,
                 validationContext,
-                root.get("name").asText(),
-                root.get("type").asText()));
+                root.get("name").toPrettyString(),
+                root.get("type").toPrettyString()));
       }
       root.replace("type", methodArgs.get(root.get("name")));
     } else if (root.get("name") != null
@@ -72,7 +72,8 @@ class UtamArgumentDeserializer extends
       // Validate if a reference type is not referenced in methodArgs already, if not, throw an
       // error
       throw new UtamError(
-          String.format(ERR_REFERENCE_MISSING, validationContext, root.get("name").asText()));
+          String.format(
+              ERR_REFERENCE_MISSING, validationContext, root.get("name").toPrettyString()));
     } else {
       methodArgs.put(root.get("name"), root.get("type"));
     }

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamArgument_DeserializeTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamArgument_DeserializeTests.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.expectThrows;
 import static utam.compiler.grammar.TestUtilities.getDeserializedObject;
-import static utam.compiler.grammar.UtamArgument.Processor.ERR_ARGS_DUPLICATE_NAMES;
+import static utam.compiler.grammar.UtamArgument.ERR_ARG_TYPE_MISMATCH;
 import static utam.compiler.grammar.UtamArgument.Processor.ERR_ARGS_WRONG_COUNT;
 import static utam.compiler.grammar.UtamArgument.getArgsProcessor;
 import static utam.compiler.helpers.TypeUtilities.FUNCTION;
@@ -92,10 +92,11 @@ public class UtamArgument_DeserializeTests {
   }
 
   /**
-   * Creating a UtamArgument object with duplicate parameter names throws the proper exception
+   * Creating a UtamArgument object with duplicate parameter names but mismatched types throws the
+   * proper exception
    */
   @Test
-  public void testCreationWithDuplicateNamesThrows() {
+  public void testCreationWithMismatchedTypesThrows() {
     String json =
         "{"
             + "  \"name\" : \"testParameterMethod\",\n"
@@ -119,8 +120,8 @@ public class UtamArgument_DeserializeTests {
 
     UtamError e = expectThrows(UtamError.class, () -> getParameters(json));
     assertThat(
-        e.getMessage(),
-        containsString(String.format(ERR_ARGS_DUPLICATE_NAMES, "testParameterMethod", "attrName")));
+        e.getCause().getMessage(),
+        containsString(String.format(ERR_ARG_TYPE_MISMATCH, "args", "\"attrName\"", "\"number\"")));
   }
 
   @Test

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamMethod_ComposeDeserializeTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamMethod_ComposeDeserializeTests.java
@@ -474,7 +474,8 @@ public class UtamMethod_ComposeDeserializeTests {
     assertThat(
         e.getCause().getMessage(),
         containsString(
-            String.format(UtamArgument.ERR_ARG_TYPE_MISMATCH, "args", "strArg", "boolean")));
+            String.format(
+                UtamArgument.ERR_ARG_TYPE_MISMATCH, "args", "\"strArg\"", "\"boolean\"")));
   }
 
   @Test
@@ -488,6 +489,6 @@ public class UtamMethod_ComposeDeserializeTests {
                     .getMethod("testReference"));
     assertThat(
         e.getCause().getMessage(),
-        containsString(String.format(UtamArgument.ERR_REFERENCE_MISSING, "args", "strArg1")));
+        containsString(String.format(UtamArgument.ERR_REFERENCE_MISSING, "args", "\"strArg1\"")));
   }
 }

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamMethod_ComposeDeserializeTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamMethod_ComposeDeserializeTests.java
@@ -21,6 +21,7 @@ import utam.core.declarative.representation.PageObjectMethod;
 import java.util.Collection;
 
 import static utam.compiler.grammar.TestUtilities.*;
+import static utam.compiler.grammar.UtamArgument.Processor.ERR_ARGS_DUPLICATE_NAMES;
 import static utam.compiler.grammar.UtamMethod.ERR_METHOD_EMPTY_STATEMENTS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -450,5 +451,43 @@ public class UtamMethod_ComposeDeserializeTests {
         + "return true;\n"
         + "})");
     PageObjectValidationTestHelper.validateMethod(context.getMethod("testComposeWaitFor"), methodInfo);
+  }
+
+  @Test
+  public void testComposeWithReferenceArgsReplacesWithMethodLevelPrimitive() {
+    MethodInfo methodInfo = new MethodInfo("testReference", "List<String>");
+    methodInfo.addParameter(new MethodParameterInfo("strArg", "String"));
+    methodInfo.addCodeLine("this.getCustomElement().someMethod(strArg)");
+    TranslationContext context = new DeserializerUtilities().getContext("composeReference");
+    PageObjectValidationTestHelper.validateMethod(context.getMethod("testReference"), methodInfo);
+  }
+
+  @Test
+  public void testComposeWithMismatchedArgTypes() {
+    UtamError e =
+        expectThrows(
+            UtamError.class,
+            () ->
+                new DeserializerUtilities()
+                    .getContext("composeMisMatchedArgs")
+                    .getMethod("testReference"));
+    assertThat(
+        e.getCause().getMessage(),
+        containsString(
+            String.format(UtamArgument.ERR_ARG_TYPE_MISMATCH, "args", "strArg", "boolean")));
+  }
+
+  @Test
+  public void testComposeWithInvalidArgReference() {
+    UtamError e =
+        expectThrows(
+            UtamError.class,
+            () ->
+                new DeserializerUtilities()
+                    .getContext("composeInvalidReference")
+                    .getMethod("testReference"));
+    assertThat(
+        e.getCause().getMessage(),
+        containsString(String.format(UtamArgument.ERR_REFERENCE_MISSING, "args", "strArg1")));
   }
 }

--- a/utam-compiler/src/test/resources/composeInvalidReference.json
+++ b/utam-compiler/src/test/resources/composeInvalidReference.json
@@ -1,0 +1,36 @@
+{
+  "elements": [
+    {
+      "name": "custom",
+      "type": "utam-test/pageObjects/custom",
+      "selector": {
+        "css": ".css"
+      }
+    }
+  ],
+  "methods": [
+    {
+      "name": "testReference",
+      "return" : "string",
+      "returnAll" : true,
+      "args": [
+        {
+          "name": "strArg",
+          "type": "string"
+        }
+      ],
+      "compose": [
+        {
+          "element": "custom",
+          "apply": "someMethod",
+          "args": [
+            {
+              "name": "strArg1",
+              "type": "reference"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/composeMisMatchedArgs.json
+++ b/utam-compiler/src/test/resources/composeMisMatchedArgs.json
@@ -1,0 +1,36 @@
+{
+  "elements": [
+    {
+      "name": "custom",
+      "type": "utam-test/pageObjects/custom",
+      "selector": {
+        "css": ".css"
+      }
+    }
+  ],
+  "methods": [
+    {
+      "name": "testReference",
+      "return" : "string",
+      "returnAll" : true,
+      "args": [
+        {
+          "name": "strArg",
+          "type": "string"
+        }
+      ],
+      "compose": [
+        {
+          "element": "custom",
+          "apply": "someMethod",
+          "args": [
+            {
+              "name": "strArg",
+              "type": "boolean"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/composeReference.json
+++ b/utam-compiler/src/test/resources/composeReference.json
@@ -1,0 +1,36 @@
+{
+  "elements": [
+    {
+      "name": "custom",
+      "type": "utam-test/pageObjects/custom",
+      "selector": {
+        "css": ".css"
+      }
+    }
+  ],
+  "methods": [
+    {
+      "name": "testReference",
+      "return" : "string",
+      "returnAll" : true,
+      "args": [
+        {
+          "name": "strArg",
+          "type": "string"
+        }
+      ],
+      "compose": [
+        {
+          "element": "custom",
+          "apply": "someMethod",
+          "args": [
+            {
+              "name": "strArg",
+              "type": "reference"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- The arguments should not reference nonexistant method level arguments
- The argument types if defined should match between compose statement level and method level arguments.