### PR TITLE
Creating methods to enable focus setting for Unit Tests in the simulator

### DIFF
--- a/utam-core/src/main/java/utam/core/selenium/utilities/WebDriverSimulator.java
+++ b/utam-core/src/main/java/utam/core/selenium/utilities/WebDriverSimulator.java
@@ -111,6 +111,7 @@ public class WebDriverSimulator {
     private String parentElementName;
     private boolean isInShadowDOM;
     private WebElement element;
+    private boolean isFocused;
 
     /**
      * Creates a new instance of the WebElementInfo class
@@ -244,7 +245,27 @@ public class WebDriverSimulator {
         objectFactory.setElementVisibility(element, isVisible);
         return this;
     }
-  
+
+    /**
+     * Marks the element info to be mocked as having focus when the driver is created.
+     *
+     * @param isFocused the boolean focus value
+     * @return this WebElementInfo object
+     */
+    public WebElementInfo withFocus(boolean isFocused) {
+      this.isFocused = isFocused;
+      return this;
+    }
+
+    /**
+     * Gets a value indicating whether the described element would be focused
+     *
+     * @return true if the element is going to be set to be focused.
+     */
+    public boolean isFocused() {
+      return isFocused;
+    }
+
     private void setChildElement(WebElementInfo childInfo, boolean isInShadowDOM) {
       childInfo.parentElementName = name;
       childInfo.isInShadowDOM = isInShadowDOM;

--- a/utam-core/src/test/java/utam/core/selenium/utilities/TestObjectFactory.java
+++ b/utam-core/src/test/java/utam/core/selenium/utilities/TestObjectFactory.java
@@ -57,6 +57,13 @@ public class TestObjectFactory extends WebDriverSimulatorObjectFactory {
             .thenReturn(elementInfo.getElement());
       }
 
+      // If this is set for more than one element then only the last element would be mocked.
+      if (elementInfo.isFocused()) {
+        WebDriver.TargetLocator targetLocator = mock(WebDriver.TargetLocator.class);
+        when(driver.switchTo()).thenReturn(targetLocator);
+        when(targetLocator.activeElement()).thenReturn(elementInfo.getElement());
+      }
+
       // Get a list all of the child element info objects that are children of this element
       List<WebElementInfo> childElementInfos =
           knownElements.values().stream()


### PR DESCRIPTION
WebElementInfo.setFocus will let developer set focus to an element in unit tests.