### PR TITLE
@W-9282057 fix number of args for selector

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamSelector.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamSelector.java
@@ -135,9 +135,9 @@ public class UtamSelector {
   }
 
   // parse selector string to find parameters %s or %d
-  private static List<TypeProvider> getParametersTypes(String str) {
+  static List<TypeProvider> getParametersTypes(String str) {
     List<TypeProvider> res = new ArrayList<>();
-    while (str.indexOf("%") > 0) {
+    while (str.indexOf("%") >= 0) {
       int index = str.indexOf("%");
       if (str.indexOf(SELECTOR_INTEGER_PARAMETER) == index) {
         res.add(PrimitiveType.NUMBER);

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamSelector_Tests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamSelector_Tests.java
@@ -9,7 +9,6 @@ package utam.compiler.grammar;
 
 import utam.compiler.helpers.PrimitiveType;
 import utam.core.declarative.representation.MethodParameter;
-import utam.core.declarative.representation.TypeProvider;
 import utam.core.framework.consumer.UtamError;
 import org.testng.annotations.Test;
 

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamSelector_Tests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamSelector_Tests.java
@@ -9,6 +9,7 @@ package utam.compiler.grammar;
 
 import utam.compiler.helpers.PrimitiveType;
 import utam.core.declarative.representation.MethodParameter;
+import utam.core.declarative.representation.TypeProvider;
 import utam.core.framework.consumer.UtamError;
 import org.testng.annotations.Test;
 
@@ -183,5 +184,10 @@ public class UtamSelector_Tests {
   public void testNullSelectorString() {
     UtamError e = expectThrows(UtamError.class, () -> new UtamSelector(null));
     assertThat(e.getMessage(), is(equalTo(ERR_SELECTOR_MISSING)));
+  }
+
+  @Test
+  public void testArgsNumber() {
+    assertThat(getParametersTypes("%s"), hasSize(1));
   }
 }


### PR DESCRIPTION
this allows to parametrize container selector
```json
{
  "elements" : [
      {
        "name" : "panel",
        "type" : "container",
        "public" : true,
        "selector": {
          "css": "%s",
          "args": [
            {
              "name": "selector",
              "type": "string"
            }
          ]
        }
      }
    ]
}
```