### PR TITLE
@W-9794410 hide underlying Element from Frame

### DIFF
--- a/utam-core/src/main/java/utam/core/element/FrameElement.java
+++ b/utam-core/src/main/java/utam/core/element/FrameElement.java
@@ -14,11 +14,4 @@ package utam.core.element;
  * @since 236
  */
 public interface FrameElement extends BasicElement {
-
-  /**
-   * gets the underlying Element object representing the frame
-   *
-   * @return the frame Element object
-   */
-  Element getFrameElement();
 }

--- a/utam-core/src/main/java/utam/core/framework/base/FrameElementImpl.java
+++ b/utam-core/src/main/java/utam/core/framework/base/FrameElementImpl.java
@@ -25,8 +25,7 @@ public class FrameElementImpl extends BasePageElement implements FrameElement {
     return createInstance(FrameElementImpl.class, element, factory);
   }
 
-  @Override
-  public Element getFrameElement() {
-    return getElement();
+  public static Element getUnwrappedElement(FrameElement frameElement) {
+    return ((FrameElementImpl)frameElement).getElement();
   }
 }

--- a/utam-core/src/main/java/utam/core/framework/element/DocumentObject.java
+++ b/utam-core/src/main/java/utam/core/framework/element/DocumentObject.java
@@ -9,6 +9,7 @@ package utam.core.framework.element;
 
 import static utam.core.element.FindContext.Type.EXISTING;
 import static utam.core.element.FindContext.Type.NULLABLE;
+import static utam.core.framework.base.FrameElementImpl.getUnwrappedElement;
 
 import java.time.Duration;
 import java.util.function.Supplier;
@@ -72,7 +73,7 @@ public class DocumentObject implements Document {
     if(frame == null) {
       throw new UtamCoreError(ERR_CANT_ENTER_NULL_FRAME);
     }
-    driver.enterFrame(frame.getFrameElement());
+    driver.enterFrame(getUnwrappedElement(frame));
   }
 
   @Override

--- a/utam-core/src/test/java/utam/core/framework/base/FrameElementTests.java
+++ b/utam-core/src/test/java/utam/core/framework/base/FrameElementTests.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static utam.core.framework.base.FrameElementImpl.createFrameInstance;
+import static utam.core.framework.base.FrameElementImpl.getUnwrappedElement;
 import static utam.core.selenium.element.ElementAdapter.NULL_ELEMENT;
 
 public class FrameElementTests {
@@ -26,7 +27,7 @@ public class FrameElementTests {
     MockUtilities mock = new MockUtilities();
     Element mockElement = mock.getElementAdapter();
     FrameElement frame = mock.getFrameElement();
-    assertThat(frame.getFrameElement(), is(sameInstance(mockElement)));
+    assertThat(getUnwrappedElement(frame), is(sameInstance(mockElement)));
   }
 
   @Test

--- a/utam-core/src/test/java/utam/core/selenium/element/DriverAdapterTests.java
+++ b/utam-core/src/test/java/utam/core/selenium/element/DriverAdapterTests.java
@@ -33,8 +33,8 @@ import utam.core.MockUtilities;
 import utam.core.driver.Document;
 import utam.core.driver.Driver;
 import utam.core.driver.Expectations;
+import utam.core.element.Element;
 import utam.core.element.FindContext.Type;
-import utam.core.element.FrameElement;
 import utam.core.framework.consumer.UtamError;
 import utam.core.framework.element.ExpectationsImpl;
 
@@ -134,8 +134,8 @@ public class DriverAdapterTests {
   @Test
   public void testEnterFrame() {
     MockUtilities mock = new MockUtilities();
-    FrameElement element = mock.getFrameElement();
-    mock.getDriverAdapter().enterFrame(element.getFrameElement());
+    Element element = mock.getElementAdapter();
+    mock.getDriverAdapter().enterFrame(element);
   }
 
   @Test


### PR DESCRIPTION
hide FrameElement.getFrameElement() to avoid misuse from test like 
`getMyFrame().getFrameElement().callDirectAPIOfElement()`