### PR TITLE
fix the issue to validate the ios class chain locator correctly

### DIFF
--- a/utam-core/src/main/java/utam/core/selenium/appium/LocatorClassChain.java
+++ b/utam-core/src/main/java/utam/core/selenium/appium/LocatorClassChain.java
@@ -38,6 +38,8 @@ public class LocatorClassChain extends LocatorBy {
 
   public LocatorClassChain(String selectorString) {
     super(selectorString);
+    // To avoid to split the string based on the / in attribute part, for example:
+    // **/XCUIElementTypeStaticText[`text == 'https://q3lex.lightning.force.com/lightning/r/Account/sdf/view'`]
     Stream.of(selectorString.split("/XCUIElement"))
         .forEach(LocatorClassChain::validateSubClassChainSelector);
   }

--- a/utam-core/src/main/java/utam/core/selenium/appium/LocatorClassChain.java
+++ b/utam-core/src/main/java/utam/core/selenium/appium/LocatorClassChain.java
@@ -38,7 +38,7 @@ public class LocatorClassChain extends LocatorBy {
 
   public LocatorClassChain(String selectorString) {
     super(selectorString);
-    Stream.of(selectorString.split("/"))
+    Stream.of(selectorString.split("/XCUIElement"))
         .forEach(LocatorClassChain::validateSubClassChainSelector);
   }
 

--- a/utam-core/src/test/java/utam/core/selenium/appium/LocatorClassChainTests.java
+++ b/utam-core/src/test/java/utam/core/selenium/appium/LocatorClassChainTests.java
@@ -173,6 +173,14 @@ public class LocatorClassChainTests {
   }
 
   @Test
+  public void testValidateClassChainSelectorWithSlashInAttribut() {
+    String locator = "**/XCUIElementTypeStaticText[`text == 'https://q3lex.lightning.force.com/lightning/r/Account/0019A00000K9wzfQAB/view'`]";
+    Locator locatorValue = LocatorBy.byClassChain(locator);
+    assertThat(locatorValue.getValue(), is(equalTo(MobileBy.iOSClassChain(locator))));
+    assertThat(locatorValue.getStringValue(), is(equalTo(locator)));
+  }
+
+  @Test
   public void testValidateClassChainSelectorUnsupportOperatorThrows() {
     UtamError e = expectThrows(UtamError.class,
         () -> LocatorBy


### PR DESCRIPTION
Originally, we use / to split the locator, but some time, the attribute part can include /, for example **/XCUIElementTypeStaticText[`text == 'https://q3lex.lightning.force.com/lightning/r/Account/0019A00000K9wzfQAB/view'`]. To handle this correctly, update to use "/XCUIElementType" to do split. Add unit test accordingly. 