### PR TITLE
@W-9919770 Bug fix in UIAutomator locator static check

### DIFF
--- a/utam-core/src/main/java/utam/core/selenium/appium/LocatorUIAutomator.java
+++ b/utam-core/src/main/java/utam/core/selenium/appium/LocatorUIAutomator.java
@@ -21,7 +21,7 @@ public class LocatorUIAutomator extends LocatorBy {
   static final String ERR_SELECTOR_UIAUTOMATOR_UNSUPPORTED_METHOD =
       "unsupported UiSelector method '%s', supported are: " + SUPPORTED_UIAUTOMATOR_METHODS;
   static final String ERR_SELECTOR_UIAUTOMATOR_UISCROLLABLE_UNSUPPORTED_METHOD =
-      "unsupported UiSelector method '%s', supported method is : scrollable";
+      "unsupported UiSelector method '%s', supported method are: scrollable, " + SUPPORTED_UIAUTOMATOR_METHODS;
 
   public LocatorUIAutomator(String selectorString) {
     super(selectorString);
@@ -37,7 +37,10 @@ public class LocatorUIAutomator extends LocatorBy {
         String match1 = uiautomator
             .substring(uiautomator.indexOf(".") + 1, uiautomator.indexOf("(", uiautomator.indexOf(".") + 1));
         if (!match1.equals("scrollable")) {
-          throw new UtamError(String.format(ERR_SELECTOR_UIAUTOMATOR_UISCROLLABLE_UNSUPPORTED_METHOD, match1));
+          if (Stream.of(LocatorUIAutomator.Method.values())
+              .noneMatch(method -> method.value.equals(match1))) {
+            throw new UtamError(String.format(ERR_SELECTOR_UIAUTOMATOR_UISCROLLABLE_UNSUPPORTED_METHOD, match1));
+          }
         }
         // Extract input to first method
         String match2 = uiautomator.substring(uiautomator.indexOf("))") + 2);

--- a/utam-core/src/test/java/utam/core/selenium/appium/LocatorUiAutomatorTests.java
+++ b/utam-core/src/test/java/utam/core/selenium/appium/LocatorUiAutomatorTests.java
@@ -117,9 +117,25 @@ public class LocatorUiAutomatorTests {
   }
   
   @Test
+  public void testUiScrollableWithResourceId() {
+    String selector = "new UiScrollable(new UiSelector().resourceId(\"com.salesforce.fieldservice.app:id/work_view\")).scrollIntoView(new UiSelector().resourceId(\"com.salesforce.chatter:id/app_launcher_menu_item\"))";
+    Locator<By> locator = new LocatorUIAutomator(selector);
+    By by = MobileBy.AndroidUIAutomator(selector);
+    assertThat(locator.getValue(), is(equalTo(by)));
+    assertThat(locator.getStringValue(), is(equalTo(selector)));
+  }
+  
+  @Test
   public void testInvalidUiScrollableMethod() {
     UtamError e = expectThrows(UtamError.class, () -> LocatorBy.byUiAutomator("new UiScrollable(new UiSelector().clickable(true)).scrollIntoView(resourceId(\"com.salesforce.chatter:id/app_launcher_menu_item\"))"));
     assertThat(e.getMessage(),
         is(equalTo(String.format(ERR_SELECTOR_UIAUTOMATOR_UISCROLLABLE_UNSUPPORTED_METHOD, "clickable"))));
+  }
+  
+  @Test
+  public void testUiScrollableUnsupportedMethod() {
+    UtamError e = expectThrows(UtamError.class, () -> LocatorBy.byUiAutomator("new UiScrollable(new UiSelector().unsupported(\"com.salesforce.chatter:id/app_launcher_menu_item\")).scrollIntoView(resourceId(\"com.salesforce.chatter:id/app_launcher_menu_item\"))"));
+    assertThat(e.getMessage(),
+        is(equalTo(String.format(ERR_SELECTOR_UIAUTOMATOR_UISCROLLABLE_UNSUPPORTED_METHOD, "unsupported"))));
   }
 }


### PR DESCRIPTION
We already support this locator - "new UiScrollable(new UiSelector().scrollable(true)).scrollIntoView(resourceId(\"com.salesforce.chatter:id/app_launcher_menu_item\"))"

This fix is to support - "new UiScrollable(new UiSelector().resourceId(\"com.salesforce.fieldservice.app:id/work_view\")).scrollIntoView(new UiSelector().resourceId(\"com.salesforce.chatter:id/app_launcher_menu_item\"))"

UiScrollable can use resourceId or other supported methods.