### PR TITLE
fix: proxy interface should be public

### DIFF
--- a/utam-core/src/main/java/utam/core/framework/base/BasePageObject.java
+++ b/utam-core/src/main/java/utam/core/framework/base/BasePageObject.java
@@ -194,10 +194,10 @@ public abstract class BasePageObject extends UtamBaseImpl implements PageObject 
 
   /**
    * dummy interface whose sole purpose is to have getElement method so that it'd be called for a
-   * proxy instance. interface should not be public
+   * proxy instance. interface should be public otherwise proxy throws IllegalArgumentException: non-public interfaces from different packages
    */
   @SuppressWarnings("unused")
-  interface HasElementGetter {
+  public interface HasElementGetter {
 
     Element getElement();
   }

--- a/utam-core/src/test/java/utam/core/OutsidePackageProxyTest.java
+++ b/utam-core/src/test/java/utam/core/OutsidePackageProxyTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root
+ * or https://opensource.org/licenses/MIT
+ */
+package utam.core;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static utam.core.framework.base.BasicElementBuilder.getUnwrappedElement;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.annotations.Test;
+import utam.core.element.Actionable;
+import utam.core.element.Clickable;
+import utam.core.framework.base.BaseRootPageObject;
+import utam.core.framework.base.PageMarker;
+
+/**
+ * this test should be in external package to test Proxy
+ *
+ * @author elizaveta.ivanova
+ * @since 238
+ */
+public class OutsidePackageProxyTest {
+
+  @Test
+  public void testProxyElementCanBeUsed() {
+    MockUtilities mockUtilities = new MockUtilities();
+    WebElement mockElement = mock(WebElement.class);
+    when(mockUtilities.getWebDriverMock().findElement(By.cssSelector("root")))
+        .thenReturn(mockElement);
+    TestProxyPageObject pageObject = mockUtilities.getFactory().create(TestProxyPageObject.class);
+    UnionType element = pageObject.getRoot();
+    element.isPresent();
+    getUnwrappedElement(element);
+  }
+
+  interface UnionType extends Actionable, Clickable { }
+
+  @SuppressWarnings("WeakerAccess")
+  @PageMarker.Find(css = "root")
+  public static class TestProxyPageObject extends BaseRootPageObject {
+
+    public UnionType getRoot() {
+      return getProxy(getRootElement(), UnionType.class);
+    }
+  }
+}

--- a/utam-core/src/test/java/utam/core/framework/base/BasePageObjectTests.java
+++ b/utam-core/src/test/java/utam/core/framework/base/BasePageObjectTests.java
@@ -9,12 +9,8 @@ package utam.core.framework.base;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static utam.core.framework.base.BasicElementBuilder.getUnwrappedElement;
 
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 import org.testng.annotations.Test;
 import utam.core.MockUtilities;
 import utam.core.element.Actionable;
@@ -28,17 +24,6 @@ import utam.core.selenium.element.LocatorBy;
  * @since 236
  */
 public class BasePageObjectTests {
-
-  @Test
-  public void testProxyElementCanBeUsedInsteadRoot() {
-    MockUtilities mockUtilities = new MockUtilities();
-    WebElement mockElement = mock(WebElement.class);
-    when(mockUtilities.getWebDriverMock().findElement(By.cssSelector("root")))
-        .thenReturn(mockElement);
-    TestProxyPageObject pageObject = mockUtilities.getFactory().create(TestProxyPageObject.class);
-    UnionType element = pageObject.getRoot();
-    element.isPresent();
-  }
 
   @Test
   public void testGetProxyDoesNotThrow() {
@@ -69,29 +54,18 @@ public class BasePageObjectTests {
 
   interface UnionType extends Actionable, Clickable { }
 
-  @SuppressWarnings("WeakerAccess")
-  @PageMarker.Find(css = "root")
-  public static class TestProxyPageObject extends BaseRootPageObject {
-
-    public UnionType getRoot() {
-      return getProxy(getRootElement(), UnionType.class);
-    }
-  }
-
   @SuppressWarnings("unused")
   static class ElementDeclaration extends BasePageObject {
+
+    @ElementMarker.Find(css = "css")
+    ElementLocation one;
+    @ElementMarker.Find(css = "css", nullable = true)
+    ElementLocation two;
+    @ElementMarker.Find(css = "css", expand = true)
+    ElementLocation three;
 
     ElementDeclaration(MockUtilities utilities, Locator root) {
       utilities.getFactory().bootstrap(this, utilities.getElementAdapter(), root);
     }
-
-    @ElementMarker.Find(css = "css")
-    ElementLocation one;
-
-    @ElementMarker.Find(css = "css", nullable = true)
-    ElementLocation two;
-
-    @ElementMarker.Find(css = "css", expand = true)
-    ElementLocation three;
   }
 }


### PR DESCRIPTION
Fixed the issue (confirmed in mobile repo) and moved tests to different package otherwise issue was not reproducible.

Error for proxy was: 

java.lang.IllegalArgumentException: non-public interfaces from different packages
	at java.base/java.lang.reflect.Proxy$ProxyBuilder.mapToModule(Proxy.java:788)
	at java.base/java.lang.reflect.Proxy$ProxyBuilder.<init>(Proxy.java:630)
	at java.base/java.lang.reflect.Proxy.lambda$getProxyConstructor$1(Proxy.java:426)
	at java.base/jdk.internal.loader.AbstractClassLoaderValue$Memoizer.get(AbstractClassLoaderValue.java:329)
	at java.base/jdk.internal.loader.AbstractClassLoaderValue.computeIfAbsent(AbstractClassLoaderValue.java:205)
	at java.base/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:424)
	at java.base/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:1006)
	at utam.core.framework.base.BasePageObject.getProxy(BasePageObject.java:174)