### PR TITLE
W-10481798 Updating BasePageElement.click method to handle browser error message

### DIFF
--- a/utam-core/src/main/java/utam/core/framework/element/BasePageElement.java
+++ b/utam-core/src/main/java/utam/core/framework/element/BasePageElement.java
@@ -171,7 +171,8 @@ public class BasePageElement extends UtamBaseImpl implements Actionable, Clickab
       getElement().click();
     } catch (Exception e) {
       if (e.getMessage()
-          .contains("javascript error: Cannot read property 'defaultView' of undefined")) {
+          .contains("javascript error: Cannot read") && e.getMessage()
+              .contains("defaultView")) {
         UtamLogger.error(
             "Error from WebElement.click(), attempting to execute javascript click instead...");
         UtamLogger.error(e);

--- a/utam-core/src/main/java/utam/core/framework/element/BasePageElement.java
+++ b/utam-core/src/main/java/utam/core/framework/element/BasePageElement.java
@@ -172,7 +172,7 @@ public class BasePageElement extends UtamBaseImpl implements Actionable, Clickab
     } catch (Exception e) {
       if (e.getMessage()
           .contains("javascript error: Cannot read") && e.getMessage()
-              .contains("defaultView")) {
+              .contains("defaultView") && e.getMessage().contains("undefined")) {
         UtamLogger.error(
             "Error from WebElement.click(), attempting to execute javascript click instead...");
         UtamLogger.error(e);


### PR DESCRIPTION
Updating BasePageElement.click method to handle latest chrome browser javascript error.
New message from chrome browser:  Cannot read properties of undefined (reading 'defaultView')
Previous: javascript error: Cannot read property 'defaultView' of undefined

