### PR TITLE
feat: Rollback availability of setting copyright via command line

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/translator/TranslatorGenerationCommand.java
+++ b/utam-compiler/src/main/java/utam/compiler/translator/TranslatorGenerationCommand.java
@@ -105,10 +105,6 @@ public class TranslatorGenerationCommand implements Callable<Integer> {
       description = "Defines how strict should be guardrails violations, possible values: 'error' or 'warning'")
   private String validationStrict;
 
-  @Option(names = {"-y", "-copyright", "--copyright"},
-      description = "Lines with a copyright header that should be added to generated page objects")
-  private List<String> copyright;
-
   private Exception thrownError;
   Integer returnCode = CommandLine.ExitCode.OK;
 
@@ -205,17 +201,19 @@ public class TranslatorGenerationCommand implements Callable<Integer> {
           getScannerConfig(packageMappingFile),
           getScanner(inputDirectory, inputFiles));
 
-      GuardrailsMode guardrailsMode = validationStrict == null? WARNING : GuardrailsMode.valueOf(validationStrict.toUpperCase());
+      GuardrailsMode guardrailsMode =
+          validationStrict == null ? WARNING : GuardrailsMode.valueOf(validationStrict.toUpperCase());
 
+      // NOTE: Copyright cannot be set from the command line; you must
+      // use a compiler config JSON settings file.
       CompilerOutputOptions outputOptions = new CompilerOutputOptions(moduleName, versionName,
-          Objects.requireNonNullElse(copyright, new ArrayList<>()));
+          new ArrayList<>());
       return new DefaultTranslatorConfiguration(
           outputOptions,
           guardrailsMode,
           sourceConfig,
           targetConfig,
           getConfiguredProfiles(profileDefinitionsFile));
-
     } catch (IOException e) {
       thrownError = e;
       returnCode = RUNTIME_ERR;


### PR DESCRIPTION
The feature to add a copyright header to generated files should be accessed through a JSON compiler configuration settings file only, rather than make it available through the command line.