### PR TITLE
fix: replace getSessionDetail with more generic getCapabilities to obtain test android device info

### DIFF
--- a/utam-core/src/main/java/utam/core/framework/context/MobilePlatformType.java
+++ b/utam-core/src/main/java/utam/core/framework/context/MobilePlatformType.java
@@ -10,6 +10,8 @@ package utam.core.framework.context;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
+
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
 
@@ -128,8 +130,9 @@ public enum MobilePlatformType implements Profile {
   }
 
   private static boolean isTablet(WebDriver driver) {
-    Object deviceScreenSizeObject = ((AppiumDriver)driver).getSessionDetail("deviceScreenSize");
-    Object deviceScreenDensityObject = ((AppiumDriver)driver).getSessionDetail("deviceScreenDensity");
+	Capabilities caps = ((AppiumDriver)driver).getCapabilities();
+	Object deviceScreenSizeObject = caps.getCapability("deviceScreenSize");
+	Object deviceScreenDensityObject = caps.getCapability("deviceScreenDensity");
 
     // For android, based on https://developer.android.com/training/multiscreen/screensizes
     // when device's dp is equal or bigger than 600, will be treated as tablet, otherwise will be phone

--- a/utam-core/src/test/java/utam/core/framework/context/MobilePlatformTypeTests.java
+++ b/utam-core/src/test/java/utam/core/framework/context/MobilePlatformTypeTests.java
@@ -24,6 +24,8 @@ import static utam.core.framework.context.MobilePlatformType.fromDriver;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
+
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -37,33 +39,47 @@ public class MobilePlatformTypeTests {
 
   @Test
   public void testGetActivePlatform() {
+	final String DEVICE_SCREEN_SIZE_NAME = "deviceScreenSize";
+	final String DEVICE_SCREEN_DENSITY_NAME = "deviceScreenDensity";
+	final String DEVICE_SCREEN_SIZE_VALUE_TABLET = "1200x1920";
+	final String DEVICE_SCREEN_DENSITY_VALUE_TABLET = "320";
+	final String DEVICE_SCREEN_SIZE_VALUE_PHONE = "1080x1920";
+	final String DEVICE_SCREEN_DENSITY_VALUE_PHONE = "480";
+
     AppiumDriver driver = mock(IOSDriver.class);
     when(driver.getSessionDetail("device")).thenReturn("iphone");
     assertThat(fromDriver(driver), is(IOS_PHONE));
+
     driver = mock(AndroidDriver.class);
-    when(driver.getSessionDetail("deviceScreenSize")).thenReturn("1200x1920");
-    when(driver.getSessionDetail("deviceScreenDensity")).thenReturn("320");
+    DesiredCapabilities desiredCaps = new DesiredCapabilities();
+    desiredCaps.setCapability(DEVICE_SCREEN_SIZE_NAME, DEVICE_SCREEN_SIZE_VALUE_TABLET);
+    desiredCaps.setCapability(DEVICE_SCREEN_DENSITY_NAME, DEVICE_SCREEN_DENSITY_VALUE_TABLET);
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
     assertThat(fromDriver(driver), is(ANDROID_TABLET));
-    when(driver.getSessionDetail("deviceScreenSize")).thenReturn("1080x1920");
-    when(driver.getSessionDetail("deviceScreenDensity")).thenReturn("480");
+    desiredCaps.setCapability(DEVICE_SCREEN_SIZE_NAME, DEVICE_SCREEN_SIZE_VALUE_PHONE);
+    desiredCaps.setCapability(DEVICE_SCREEN_DENSITY_NAME, DEVICE_SCREEN_DENSITY_VALUE_PHONE);
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
     assertThat(fromDriver(driver), is(ANDROID_PHONE));
+
     driver = mock(AppiumDriver.class);
     assertThat(fromDriver(driver), is(WEB));
-    DesiredCapabilities capabilities = new DesiredCapabilities();
-    capabilities.setPlatform(Platform.MAC);
-    when(driver.getCapabilities()).thenReturn(capabilities);
+    desiredCaps = new DesiredCapabilities();
+    desiredCaps.setPlatform(Platform.MAC);
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
     when(driver.getSessionDetail("device")).thenReturn("iPad");
     assertThat(fromDriver(driver), is(IOS_TABLET));
-    capabilities.setPlatform(Platform.LINUX);
-    when(driver.getCapabilities()).thenReturn(capabilities);
-    when(driver.getSessionDetail("deviceScreenSize")).thenReturn("1080x1920");
-    when(driver.getSessionDetail("deviceScreenDensity")).thenReturn("480");
+    desiredCaps.setPlatform(Platform.LINUX);
+    desiredCaps.setCapability(DEVICE_SCREEN_SIZE_NAME, DEVICE_SCREEN_SIZE_VALUE_PHONE);
+    desiredCaps.setCapability(DEVICE_SCREEN_DENSITY_NAME, DEVICE_SCREEN_DENSITY_VALUE_PHONE);
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
     assertThat(fromDriver(driver), is(ANDROID_PHONE));
-    when(driver.getSessionDetail("deviceScreenSize")).thenReturn("1200x1920");
-    when(driver.getSessionDetail("deviceScreenDensity")).thenReturn("320");
+    desiredCaps.setCapability(DEVICE_SCREEN_SIZE_NAME, DEVICE_SCREEN_SIZE_VALUE_TABLET);
+    desiredCaps.setCapability(DEVICE_SCREEN_DENSITY_NAME, DEVICE_SCREEN_DENSITY_VALUE_TABLET);
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
     assertThat(fromDriver(driver), is(ANDROID_TABLET));
-    capabilities.setPlatform(Platform.WINDOWS);
-    when(driver.getCapabilities()).thenReturn(capabilities);
+    desiredCaps = new DesiredCapabilities();
+    desiredCaps.setPlatform(Platform.WINDOWS);
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
     assertThat(fromDriver(driver), is(WEB));
   }
 

--- a/utam-core/src/test/java/utam/core/selenium/factory/WebDriverFactoryTests.java
+++ b/utam-core/src/test/java/utam/core/selenium/factory/WebDriverFactoryTests.java
@@ -11,6 +11,8 @@ import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
 import utam.core.driver.Driver;
 import utam.core.driver.DriverType;
 import org.testng.annotations.Test;
@@ -53,14 +55,21 @@ public class WebDriverFactoryTests {
 
     @Test
     public void testGetAdapter() {
+    	final String DEVICE_SCREEN_SIZE_NAME = "deviceScreenSize";
+    	final String DEVICE_SCREEN_DENSITY_NAME = "deviceScreenDensity";
+    	final String DEVICE_SCREEN_SIZE_VALUE_PHONE = "1080x1920";
+    	final String DEVICE_SCREEN_DENSITY_VALUE_PHONE = "480";
+
         IOSDriver iosDriver = mock(IOSDriver.class);
         when(iosDriver.getSessionDetail("device")).thenReturn("iphone");
         assertThat(getAdapterForTest(iosDriver), instanceOf(
             MobileDriverAdapter.class));
 
         AndroidDriver androidDriver = mock(AndroidDriver.class);
-        when(androidDriver.getSessionDetail("deviceScreenSize")).thenReturn("1080x1920");
-        when(androidDriver.getSessionDetail("deviceScreenDensity")).thenReturn("480");
+        DesiredCapabilities desiredCaps = new DesiredCapabilities();
+        desiredCaps.setCapability(DEVICE_SCREEN_SIZE_NAME, DEVICE_SCREEN_SIZE_VALUE_PHONE);
+        desiredCaps.setCapability(DEVICE_SCREEN_DENSITY_NAME, DEVICE_SCREEN_DENSITY_VALUE_PHONE);
+        when(androidDriver.getCapabilities()).thenReturn(desiredCaps);
         assertThat(getAdapterForTest(androidDriver), instanceOf(MobileDriverAdapter.class));
 
         AppiumDriver appiumDriver = mock(AppiumDriver.class);


### PR DESCRIPTION
getSessionDetail is from HasSessionDetails which is for JWP protocol only. Therefore, if the test uses W3C protocol, the test will hit getSessionDetail not implement error. In order to handle the test that either uses JWP or W3C protocols, switch to using the more generic getCapabilites to query the device information for screen size and screen density. 

Update the related unit tests accordingly. 