### PR TITLE
refactor: ability to check active element inside shadow

### DIFF
--- a/utam-core/src/main/java/utam/core/element/BasicElement.java
+++ b/utam-core/src/main/java/utam/core/element/BasicElement.java
@@ -61,10 +61,9 @@ public interface BasicElement extends UtamBase {
   String getValue();
 
   /**
-   * checks if current element has focus <br>
-   * uses Selenium WebDriver.switchTo().activeElement().equals(WebDriver) <br>
-   * Throws exception if element not found within timeout
-   * @return true if current element has focus
+   * Check if element has focus (is active) inside document or its parent shadow root
+   *
+   * @return true if current element is active
    */
   boolean isFocused();
 }

--- a/utam-core/src/main/java/utam/core/element/Element.java
+++ b/utam-core/src/main/java/utam/core/element/Element.java
@@ -116,9 +116,9 @@ public interface Element {
   void moveTo();
 
   /**
-   * check if element has focus
+   * Check if element has focus (is active) inside document or its parent shadow root
    *
-   * @return boolean
+   * @return true if current element is active
    */
   boolean hasFocus();
 

--- a/utam-core/src/test/java/utam/core/selenium/element/ElementAdapterTests.java
+++ b/utam-core/src/test/java/utam/core/selenium/element/ElementAdapterTests.java
@@ -27,6 +27,8 @@ import static utam.core.selenium.element.ElementAdapter.BLUR_VIA_JAVASCRIPT;
 import static utam.core.selenium.element.ElementAdapter.CLICK_VIA_JAVASCRIPT;
 import static utam.core.selenium.element.ElementAdapter.ERR_NULL_ELEMENT;
 import static utam.core.selenium.element.ElementAdapter.FOCUS_VIA_JAVASCRIPT;
+import static utam.core.selenium.element.ElementAdapter.IS_PARENT_NODE_SHADOW_ROOT_JS;
+import static utam.core.selenium.element.ElementAdapter.ROOT_NODE_GET_ACTIVE_ELEMENT_JS;
 import static utam.core.selenium.element.ElementAdapter.SCROLL_CENTER_VIA_JAVASCRIPT;
 import static utam.core.selenium.element.ElementAdapter.SCROLL_TOP_VIA_JAVASCRIPT;
 import static utam.core.selenium.element.LocatorBy.byCss;
@@ -39,6 +41,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.testng.annotations.Test;
 import utam.core.MockUtilities;
+import utam.core.driver.Driver;
 import utam.core.element.DragAndDropOptions;
 import utam.core.element.Element;
 import utam.core.element.Element.ScrollOptions;
@@ -172,6 +175,18 @@ public class ElementAdapterTests {
     when(targetLocator.activeElement()).thenReturn(mock(WebElement.class));
     assertThat("element has no focus", element.hasFocus(), is(false));
     when(targetLocator.activeElement()).thenReturn(mock.getWebElementMock());
+    assertThat("element has focus", element.hasFocus(), is(true));
+  }
+
+  @Test
+  public void testHasFocusInsideShadowRoot() {
+    MockUtilities mockUtils = new MockUtilities();
+    WebElement elementMock = mockUtils.getWebElementMock();
+    Driver driverAdapterMock = mockUtils.getDriverAdapter();
+    Element element = mockUtils.getElementAdapter();
+    when(driverAdapterMock.executeScript(contains(IS_PARENT_NODE_SHADOW_ROOT_JS), refEq(elementMock))).thenReturn(true);
+    assertThat("element has no focus", element.hasFocus(), is(false));
+    when(driverAdapterMock.executeScript(contains(ROOT_NODE_GET_ACTIVE_ELEMENT_JS), refEq(elementMock))).thenReturn(elementMock);
     assertThat("element has focus", element.hasFocus(), is(true));
   }
 


### PR DESCRIPTION
This PR fixes an issue of isFocused not working for elements inside shadow DOM. According to https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/activeElement for elements inside shadowRoot focus is defined by shadowRoot.activeElement and not by document.activeElement

If element has shadowHost, check if current element is same as shadowHost.shadowRoot.activeElement
Corresponding PR for JS https://github.com/salesforce/utam-js/pull/276