### PR TITLE
fix: nullable element should not throw exception

### DIFF
--- a/utam-core/src/main/java/utam/core/element/Element.java
+++ b/utam-core/src/main/java/utam/core/element/Element.java
@@ -20,19 +20,20 @@ public interface Element {
   /**
    * find and element with a given locator inside current element
    *
-   * @param by                 locator
-   * @return instance of the found element or "null" element (with isNull returning true) for
-   * nullable context
+   * @param by         locator
+   * @param isNullable boolean, true if element can be absent
+   * @return instance of the found element or null for nullable
    */
-  Element findElement(Locator by);
+  Element findElement(Locator by, boolean isNullable);
 
   /**
    * find all elements with a given locator inside current element
    *
-   * @param by            locator
-   * @return list of found elements or empty list for nullable context
+   * @param by         locator
+   * @param isNullable boolean, true if element can be absent
+   * @return list of found elements or empty list for nullable
    */
-  List<Element> findElements(Locator by);
+  List<Element> findElements(Locator by, boolean isNullable);
 
   /**
    * get number of elements with a given locator inside current element

--- a/utam-core/src/main/java/utam/core/framework/base/ElementLocation.java
+++ b/utam-core/src/main/java/utam/core/framework/base/ElementLocation.java
@@ -37,16 +37,6 @@ public final class ElementLocation {
     return new ShadowRootElementAdapter(scope);
   }
 
-  private boolean isNullableAndNull(Element scope) {
-    if (!findContext.isNullable()) {
-      return false;
-    }
-    if (scope == null) {
-      return true;
-    }
-    return scope.containsElements(locator) <= 0;
-  }
-
   /**
    * apply parameters to locator and find element or return null
    *
@@ -55,11 +45,12 @@ public final class ElementLocation {
    */
   ElementFound find(Element scopeElement) {
     Element transformedScope = transformScope(scopeElement);
-    if (isNullableAndNull(transformedScope)) {
+    if (scopeElement == null && findContext.isNullable()) {
       return null;
     }
-    Element foundElement = transformedScope.findElement(locator);
-    return new ElementFound(locator, foundElement);
+    Element foundElement = transformedScope.findElement(locator, findContext.isNullable());
+    // null only returned for nullable
+    return foundElement == null? null : new ElementFound(locator, foundElement);
   }
 
   /**
@@ -70,10 +61,14 @@ public final class ElementLocation {
    */
   List<ElementFound> findList(Element scopeElement) {
     Element transformedScope = transformScope(scopeElement);
-    if (isNullableAndNull(transformedScope)) {
+    if (scopeElement == null && findContext.isNullable()) {
       return null;
     }
-    List<Element> foundList = transformedScope.findElements(locator);
+    List<Element> foundList = transformedScope.findElements(locator, findContext.isNullable());
+    // null only returned for nullable
+    if(foundList == null) {
+      return null;
+    }
     return foundList
         .stream()
         .map(e -> new ElementFound(locator, e))

--- a/utam-core/src/main/java/utam/core/framework/consumer/UtamLoaderImpl.java
+++ b/utam-core/src/main/java/utam/core/framework/consumer/UtamLoaderImpl.java
@@ -131,7 +131,7 @@ public class UtamLoaderImpl implements UtamLoader {
         driver instanceof MobileDriverAdapter
             ? new MobileElementAdapter(webElement, driver) : new ElementAdapter(webElement, driver);
     // 2. scope root inside wrapper
-    Element element = scope.findElement(utamPageObjectRoot);
+    Element element = scope.findElement(utamPageObjectRoot, false);
     T instance = factory.getPageContext().getBean(utamPageObjectType);
     // 3. inject root
     factory.bootstrap(instance, element, utamPageObjectRoot);

--- a/utam-core/src/main/java/utam/core/selenium/element/ElementAdapter.java
+++ b/utam-core/src/main/java/utam/core/selenium/element/ElementAdapter.java
@@ -109,10 +109,13 @@ public class ElementAdapter implements Element {
 
   @Override
   @SuppressWarnings("rawtypes")
-  public Element findElement(Locator locator) {
+  public Element findElement(Locator locator, boolean isNullable) {
     By by = ((LocatorBy) locator).getValue();
     WebElement res = getWebElement().findElement(by);
     if (res == null) { //this can happen for mock in unit tests
+      if(isNullable) {
+        return null;
+      }
       throw new NoSuchElementException(getNotFoundErr(locator));
     }
     return wrapElement(res);
@@ -120,10 +123,13 @@ public class ElementAdapter implements Element {
 
   @Override
   @SuppressWarnings("rawtypes")
-  public List<Element> findElements(Locator locator) {
+  public List<Element> findElements(Locator locator, boolean isNullable) {
     By by = ((LocatorBy) locator).getValue();
     List<WebElement> found = getWebElement().findElements(by);
     if (found == null || found.isEmpty()) {
+      if(isNullable) {
+        return null;
+      }
       throw new NoSuchElementException(getNotFoundErr(locator));
     }
     return found.stream().map(this::wrapElement).collect(Collectors.toList());

--- a/utam-core/src/main/java/utam/core/selenium/element/ShadowRootElementAdapter.java
+++ b/utam-core/src/main/java/utam/core/selenium/element/ShadowRootElementAdapter.java
@@ -9,6 +9,7 @@ package utam.core.selenium.element;
 
 import static utam.core.selenium.element.DriverAdapter.getNotFoundErr;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.openqa.selenium.By;
@@ -35,26 +36,35 @@ public class ShadowRootElementAdapter extends ElementAdapter {
   }
 
   @Override
-  public Element findElement(Locator locator) {
-    By by = ((LocatorBy) locator).getValue();
-    WebElement res = driverAdapter
-        .waitFor(() -> getWebElement().findElement(by), getNotFoundErr(locator),
-            driverAdapter.getDriverConfig().getImplicitTimeout());
-    return wrapElement(res);
+  public Element findElement(Locator locator, boolean isNullable) {
+    List<Element> res = findElements(locator, isNullable);
+    // null only returned for nullable, otherwise throws
+    if(res == null) {
+      return null;
+    }
+    return res.get(0);
   }
 
   @Override
-  public List<Element> findElements(Locator locator) {
+  public List<Element> findElements(Locator locator, boolean isNullable) {
     By by = ((LocatorBy) locator).getValue();
     List<WebElement> res = driverAdapter
         .waitFor(() -> {
               List<WebElement> found = getWebElement().findElements(by);
               if (found == null || found.isEmpty()) {
+                if(isNullable) {
+                  return new ArrayList<>();
+                }
                 throw new NoSuchElementException(getNotFoundErr(locator));
               }
               return found;
             }, getNotFoundErr(locator),
             driverAdapter.getDriverConfig().getImplicitTimeout());
+    // empty only returned for nullable, otherwise throws
+    if(res.isEmpty()) {
+      return null;
+    }
     return res.stream().map(el -> wrapElement(el)).collect(Collectors.toList());
   }
+
 }

--- a/utam-core/src/test/java/utam/core/selenium/element/ShadowRootWebElementTests.java
+++ b/utam-core/src/test/java/utam/core/selenium/element/ShadowRootWebElementTests.java
@@ -14,11 +14,22 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import utam.core.MockUtilities;
+import utam.core.element.Element;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.expectThrows;
+import static utam.core.selenium.element.ElementAdapterTests.ELEMENT_NOT_FOUND_ERROR;
+import static utam.core.selenium.element.ElementAdapterTests.NOT_FOUND_SELECTOR;
+import static utam.core.selenium.element.ElementAdapterTests.findNotNullable;
+import static utam.core.selenium.element.ElementAdapterTests.findNotNullables;
+import static utam.core.selenium.element.ElementAdapterTests.findNullable;
+import static utam.core.selenium.element.ElementAdapterTests.findNullables;
+import static utam.core.selenium.element.LocatorBy.byCss;
 import static utam.core.selenium.element.ShadowRootWebElement.GET_SHADOW_ROOT_QUERY_SELECTOR;
 import static utam.core.selenium.element.ShadowRootWebElement.GET_SHADOW_ROOT_QUERY_SELECTOR_ALL;
 
@@ -311,5 +322,68 @@ public class ShadowRootWebElementTests {
     assertThat(
         ShadowRootWebElement.getElementsWithFirefoxWorkaround(map),
         is(equalTo(Collections.singletonList(shadowRootWebElement))));
+  }
+
+  @Test
+  public void testFindElementInShadow() {
+    MockUtilities mock = new MockUtilities();
+    final String FOUND_SELECTOR = "found";
+    mock.setShadowMock(mock.getWebElementMock(), FOUND_SELECTOR);
+    Element scope = new ShadowRootElementAdapter(mock.getElementAdapter());
+    assertThat(findNotNullable(byCss(FOUND_SELECTOR), scope), is(notNullValue()));
+  }
+
+  @Test
+  public void testFindNullableElementInShadow() {
+    MockUtilities mock = new MockUtilities();
+    final String FOUND_SELECTOR = "found";
+    mock.setShadowMock(mock.getWebElementMock(), FOUND_SELECTOR);
+    Element scope = new ShadowRootElementAdapter(mock.getElementAdapter());
+    assertThat(findNullable(byCss(FOUND_SELECTOR), scope), is(notNullValue()));
+  }
+
+  @Test
+  public void testFindElementInShadowNotFound() {
+    Element scope = new ShadowRootElementAdapter(new MockUtilities().getElementAdapter());
+    Exception e = expectThrows(NoSuchElementException.class, () -> findNotNullable(byCss(NOT_FOUND_SELECTOR), scope));
+    assertThat(e.getMessage(), containsString(ELEMENT_NOT_FOUND_ERROR));
+  }
+
+  @Test
+  public void testFindNullableElementInShadowNotFound() {
+    Element scope = new ShadowRootElementAdapter(new MockUtilities().getElementAdapter());
+    assertNull(findNullable(byCss(NOT_FOUND_SELECTOR), scope));
+  }
+
+  @Test
+  public void testFindElementsInShadow() {
+    MockUtilities mock = new MockUtilities();
+    final String FOUND_SELECTOR = "found";
+    mock.setShadowMock(mock.getWebElementMock(), FOUND_SELECTOR);
+    Element scope = new ShadowRootElementAdapter(mock.getElementAdapter());
+    assertThat(findNotNullables(byCss(FOUND_SELECTOR), scope), is(not(empty())));
+  }
+
+  @Test
+  public void testFindNullableElementsInShadow() {
+    MockUtilities mock = new MockUtilities();
+    final String FOUND_SELECTOR = "found";
+    mock.setShadowMock(mock.getWebElementMock(), FOUND_SELECTOR);
+    Element scope = new ShadowRootElementAdapter(mock.getElementAdapter());
+    assertThat(findNotNullables(byCss(FOUND_SELECTOR), scope), is(not(empty())));
+  }
+
+  @Test
+  public void testFindElementsInShadowNotFound() {
+    Element scope = new ShadowRootElementAdapter(new MockUtilities().getElementAdapter());
+    Exception e = expectThrows(NoSuchElementException.class, () -> findNotNullables(byCss(NOT_FOUND_SELECTOR), scope));
+    assertThat(e.getMessage(), containsString(ELEMENT_NOT_FOUND_ERROR));
+  }
+
+  @Test
+  public void testFindNullableElementsInShadowNotFound() {
+    MockUtilities mock = new MockUtilities();
+    Element scope = new ShadowRootElementAdapter(mock.getElementAdapter());
+    assertNull(findNullables(byCss(NOT_FOUND_SELECTOR), scope));
   }
 }


### PR DESCRIPTION
For tests executed remotely and slowly and for element that can disappear like lightning-spinner, between line where we check presense and  attempt to find, element's state changes, so instead old code:
```java
if (isNullableAndNull(transformedScope)) {
    return null;
}
// between next line and previous one element disappears
Element foundElement = transformedScope.findElement(locator);
```
we now make just one call to find element
```java
List<Element> foundList = transformedScope.findElements(locator, findContext.isNullable());
// null only returned for nullable
if(foundList == null) {
      return null;
}
```