### PR TITLE
refactor: context switching for only root POs

### DIFF
--- a/utam-core/src/main/java/utam/core/framework/base/PageObjectsFactoryImpl.java
+++ b/utam-core/src/main/java/utam/core/framework/base/PageObjectsFactoryImpl.java
@@ -85,7 +85,10 @@ public class PageObjectsFactoryImpl implements PageObjectsFactory {
     bootstrapElements(pageObject);
     PlatformType mobileContextType = PlatformType.from(pageObject.getClass());
     // only mobile driver implementation actually changes context
-    getDriver().setPageContext(mobileContextType);
+    if (instance instanceof RootPageObject) {
+    	// do context switching for only root POs as child POs are within the required context already
+    	getDriver().setPageContext(mobileContextType);
+    }
   }
 
   @Override

--- a/utam-core/src/main/java/utam/core/selenium/appium/MobileDriverAdapter.java
+++ b/utam-core/src/main/java/utam/core/selenium/appium/MobileDriverAdapter.java
@@ -90,10 +90,12 @@ public class MobileDriverAdapter extends DriverAdapter implements Driver {
         mobilePlatform == MobilePlatformType.ANDROID_TABLET) {
       Set<String> windowHandles = appiumDriver.getWindowHandles();
       for (String windowHandle : windowHandles) {
-        AppiumDriver newDriver = (AppiumDriver) appiumDriver.switchTo().window(windowHandle);
-        String currentTitle = newDriver.getTitle();
-        if (!currentTitle.isEmpty() && currentTitle.equalsIgnoreCase(title)) {
-          return newDriver;
+        if(!windowHandle.equals(NATIVE_CONTEXT_HANDLE)) {
+          AppiumDriver newDriver = (AppiumDriver) appiumDriver.switchTo().window(windowHandle);
+          String currentTitle = newDriver.getTitle();
+          if (!currentTitle.isEmpty() && currentTitle.equalsIgnoreCase(title)) {
+            return newDriver;
+          }
         }
       }
     }


### PR DESCRIPTION
This is applicable for only mobile webviews. As per the current implementation, context is switched to webview for all web page objects implicitly when bootsrapped. This involves multiple commands to get available contexts, switch to webview context and validate the title.
For child page objects, since the context is already set via root, this is an overhead. This change does a root PO check thereby avoiding repeated context switch and improves the speed of the mobile tests involving webviews.

utam-js PR https://github.com/salesforce/utam-js/pull/295