### PR TITLE
fix: remove redundant property from lint config

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
@@ -60,7 +60,6 @@ public class LintingConfigJson implements LintingConfig {
       null,
       null,
       null,
-      null,
       null
   );
   private final List<LintingRuleImpl> localRules = new ArrayList<>();
@@ -72,7 +71,6 @@ public class LintingConfigJson implements LintingConfig {
   @JsonCreator
   LintingConfigJson(
       @JsonProperty(value = "throwError") Boolean interruptCompilation,
-      @JsonProperty(value = "outputFile") String outputFileName,
       @JsonProperty(value = "printToConsole") Boolean isPrintToConsole,
       @JsonProperty(value = "duplicateSelectors") UniqueSelectorInsidePageObject uniqueSelectors,
       @JsonProperty(value = "requiredRootDescription") RequiredRootDescription requiredRootDescription,

--- a/utam-compiler/src/test/java/utam/compiler/lint/LintingRuleTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/lint/LintingRuleTests.java
@@ -132,7 +132,6 @@ public class LintingRuleTests {
     LintingConfig configuration = new LintingConfigJson(
         DEFAULT_THROWS_ERROR,
         null,
-        null,
         new UniqueSelectorInsidePageObject(LintingError.ViolationLevel.warning, exceptions),
         new RequiredRootDescription(LintingError.ViolationLevel.warning, exceptions),
         null,


### PR DESCRIPTION
Config parameter was moved outside "lint" while doing sarif work, see https://utam.dev/guide/java-guide#compiler-setup

Docs fixed as well, see https://github.com/salesforce-experience-platform/utam-docs/pull/389