### PR TITLE
feat: support for custom message inside waitFor

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamElementFilter.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamElementFilter.java
@@ -66,7 +66,7 @@ final class UtamElementFilter {
     VALIDATION.validateNotEmptyString(this.applyMethod, parserContext, "apply");
     ArgumentsProvider provider = new ArgumentsProvider(argsNode, parserContext);
     ParametersContext parametersContext = new StatementParametersContext(parserContext, context, null);
-    List<UtamArgument> arguments = provider.getArguments(true);
+    List<UtamArgument> arguments = provider.getArguments(UtamArgument.ArgsValidationMode.LITERAL_ALLOWED);
     arguments
         .stream()
         .map(arg -> arg.asParameter(context, null, parametersContext))

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamMatcher.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamMatcher.java
@@ -100,7 +100,7 @@ class UtamMatcher {
           .readNode(matcherNode, UtamMatcher.class, VALIDATION.getErrorMessage(1200, parserContext)));
       ArgumentsProvider provider = new ArgumentsProvider(matcher.argsNode, parserContext);
       ParametersContext parametersContext = new StatementParametersContext(parserContext, context, null);
-      List<UtamArgument> arguments = provider.getArguments(true);
+      List<UtamArgument> arguments = provider.getArguments(UtamArgument.ArgsValidationMode.LITERAL_ALLOWED);
       arguments
           .stream()
           .map(arg -> arg.asParameter(context, null, parametersContext))
@@ -135,7 +135,7 @@ class UtamMatcher {
           .readNode(matcherNode, UtamMatcher.class, VALIDATION.getErrorMessage(1200, parserContext));
       ArgumentsProvider provider = new ArgumentsProvider(matcher.argsNode, parserContext);
       ParametersContext parametersContext = new StatementParametersContext(parserContext, context, methodContext);
-      List<UtamArgument> arguments = provider.getArguments(true);
+      List<UtamArgument> arguments = provider.getArguments(UtamArgument.ArgsValidationMode.LITERAL_ALLOWED);
       arguments
           .stream()
           .map(arg -> arg.asParameter(context, methodContext, parametersContext))

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamMethod.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamMethod.java
@@ -38,7 +38,7 @@ abstract class UtamMethod {
     VALIDATION.validateNotEmptyString(name, "method", "name");
     String parserContext = String.format("method \"%s\"", name);
     this.description = processMethodDescriptionNode(descriptionNode, parserContext);
-    this.arguments = processArgsNode(argsNode, parserContext, false);
+    this.arguments = processArgsNode(argsNode, parserContext, UtamArgument.ArgsValidationMode.LITERAL_NOT_ALLOWED);
   }
 
   /**

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamMethodAction.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamMethodAction.java
@@ -290,13 +290,13 @@ public abstract class UtamMethodAction {
     }
 
     /**
-     * get list of arguments
+     * get list of arguments after validation
      *
-     * @param isLiteralsAllowed boolean
-     * @return list
+     * @param argsValidationMode predicate and method declaration can't have literals
+     * @return list of args
      */
-    final List<UtamArgument> getArguments(boolean isLiteralsAllowed) {
-      return processArgsNode(argsNode, argsParserContext, isLiteralsAllowed);
+    List<UtamArgument> getArguments(UtamArgument.ArgsValidationMode argsValidationMode) {
+      return processArgsNode(argsNode, argsParserContext, argsValidationMode);
     }
 
     /**

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamMethodActionApply.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamMethodActionApply.java
@@ -251,7 +251,7 @@ class UtamMethodActionApply extends UtamMethodAction {
       String parserContext = String.format("method \"%s\"", methodContext.getName());
       ArgumentsProvider argumentsProvider = new ArgumentsProvider(argsNode, parserContext);
       ParametersContext parametersContext = new StatementParametersContext(parserContext, context, methodContext);
-      List<UtamArgument> arguments = argumentsProvider.getArguments(true);
+      List<UtamArgument> arguments = argumentsProvider.getArguments(UtamArgument.ArgsValidationMode.LITERAL_ALLOWED);
       arguments
           .stream()
           .map(argument -> argument.asParameter(context, methodContext, parametersContext))
@@ -337,7 +337,7 @@ class UtamMethodActionApply extends UtamMethodAction {
       String parserContext = String.format("method \"%s\"", methodContext.getName());
       ParametersContext parametersContext = new StatementParametersContext(parserContext, context, methodContext);
       ArgumentsProvider argumentsProvider = new ArgumentsProvider(argsNode, parserContext);
-      List<UtamArgument> arguments = argumentsProvider.getArguments(true);
+      List<UtamArgument> arguments = argumentsProvider.getArguments(UtamArgument.ArgsValidationMode.LITERAL_ALLOWED);
       arguments
           .stream()
           .map(argument -> argument.asParameter(context, methodContext, parametersContext))

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamMethodActionGetter.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamMethodActionGetter.java
@@ -90,7 +90,7 @@ class UtamMethodActionGetter extends UtamMethodAction {
           context,
           methodContext);
       ArgumentsProvider provider = new ArgumentsProvider(argsNode, parserContext);
-      List<UtamArgument> arguments = provider.getArguments(true);
+      List<UtamArgument> arguments = provider.getArguments(UtamArgument.ArgsValidationMode.LITERAL_ALLOWED);
       arguments
           .stream()
           .map(arg -> arg.asParameter(context, methodContext, parametersContext))
@@ -143,7 +143,7 @@ class UtamMethodActionGetter extends UtamMethodAction {
     private List<MethodParameter> getParameters() {
       String parserContext = String.format("method \"%s\"", methodContext.getName());
       ArgumentsProvider provider = new ArgumentsProvider(argsNode, parserContext);
-      List<UtamArgument> arguments = provider.getArguments(true);
+      List<UtamArgument> arguments = provider.getArguments(UtamArgument.ArgsValidationMode.LITERAL_ALLOWED);
       List<MethodParameter> getterNonLiteralParameters = elementContext.getGetterNonLiteralParameters();
       ParametersContext parametersContext = new StatementParametersContext(parserContext,
           context,

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamSelector.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamSelector.java
@@ -144,7 +144,7 @@ class UtamSelector extends UtamRootSelector {
       List<TypeProvider> expectedArgsTypes = getParametersTypes(getLocator().getStringValue(), selectorHolder);
       ArgumentsProvider provider = new ArgumentsProvider(argsNode, parserContext);
       ParametersContext parametersContext = new StatementParametersContext(parserContext, context, methodContext);
-      List<UtamArgument> arguments = provider.getArguments(true);
+      List<UtamArgument> arguments = provider.getArguments(UtamArgument.ArgsValidationMode.LITERAL_ALLOWED);
       List<MethodParameter> parameters = arguments
           .stream()
           .map(arg -> arg.asParameter(context, methodContext, parametersContext))

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamUtilityMethodAction.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamUtilityMethodAction.java
@@ -67,7 +67,7 @@ class UtamUtilityMethodAction {
     VALIDATION.validateNotEmptyString(externalClassPath, parserContext, "type");
     ParametersContext parametersContext = new StatementParametersContext(parserContext, context, methodContext);
     ArgumentsProvider argumentsProvider = new ArgumentsProvider(argsNode, parserContext);
-    List<UtamArgument> arguments = argumentsProvider.getArguments(true);
+    List<UtamArgument> arguments = argumentsProvider.getArguments(UtamArgument.ArgsValidationMode.LITERAL_ALLOWED);
     arguments
         .stream()
         .map(arg -> arg.asParameter(context, methodContext, parametersContext))

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamMethodActionWaitForTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamMethodActionWaitForTests.java
@@ -13,6 +13,7 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.testng.Assert.expectThrows;
 
 import org.testng.annotations.Test;
+import utam.compiler.UtamCompilationError;
 import utam.compiler.helpers.TranslationContext;
 import utam.compiler.representation.PageObjectValidationTestHelper;
 import utam.compiler.representation.PageObjectValidationTestHelper.MethodInfo;
@@ -37,8 +38,17 @@ public class UtamMethodActionWaitForTests {
   @Test
   public void nestedPredicateThrows() {
     String expectedError = "error 615: method \"test\" statement: nested waitFor is not supported";
-    UtamError e = expectThrows(UtamError.class,
+    UtamError e = expectThrows(UtamCompilationError.class,
         () -> new DeserializerUtilities().getContext("validate/compose/nestedWait"));
+    assertThat(e.getMessage(), containsString(expectedError));
+  }
+
+  @Test
+  public void predicateWithIncorrectSecondArgsThrows() {
+    String expectedError = "error 109: method \"test\": parameter \"true\" has incorrect type: " +
+            "expected \"literal string\", found \"Boolean\"";
+    UtamError e = expectThrows(UtamCompilationError.class,
+            () -> new DeserializerUtilities().getContext("validate/compose/waitForIncorrectMessageArg"));
     assertThat(e.getMessage(), containsString(expectedError));
   }
 
@@ -113,7 +123,7 @@ public class UtamMethodActionWaitForTests {
         + "RootElement proot0 = this.getRoot();\n"
         + "proot0.focus();\n"
         + "return true;\n"
-        + "})");
+        + "}, \"custom error message\")");
     PageObjectValidationTestHelper.validateMethod(method, methodInfo);
   }
 

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamPageObjectBeforeLoadTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamPageObjectBeforeLoadTests.java
@@ -81,7 +81,7 @@ public class UtamPageObjectBeforeLoadTests {
         + "BasePageElement proot0 = this.getRootElement();\n"
         + "Boolean pstatement0 = proot0.isPresent();\n"
         + "return pstatement0;\n"
-        + "})");
+        + "}, \"message\")");
     methodInfo.addCodeLine("return statement0");
     PageObjectValidationTestHelper.validateMethod(context.getMethod(METHOD_NAME), methodInfo);
   }

--- a/utam-compiler/src/test/resources/beforeload/waitForRootPresence.json
+++ b/utam-compiler/src/test/resources/beforeload/waitForRootPresence.json
@@ -11,6 +11,9 @@
               "apply" : "isPresent"
             }
           ]
+        },
+        {
+          "value" : "message"
         }
       ]
     }

--- a/utam-compiler/src/test/resources/validate/compose/waitForIncorrectMessageArg.json
+++ b/utam-compiler/src/test/resources/validate/compose/waitForIncorrectMessageArg.json
@@ -1,5 +1,4 @@
 {
-  "type" : "actionable",
   "methods": [
     {
       "name": "test",
@@ -12,12 +11,12 @@
               "predicate": [
                 {
                   "element" : "root",
-                  "apply" : "focus"
+                  "apply" : "isPresent"
                 }
               ]
             },
             {
-              "value" : "custom error message"
+              "value" : true
             }
           ]
         }

--- a/utam-core/src/main/java/utam/core/framework/base/ContainerElementPageObject.java
+++ b/utam-core/src/main/java/utam/core/framework/base/ContainerElementPageObject.java
@@ -93,4 +93,9 @@ public final class ContainerElementPageObject extends ContainerElementImpl imple
   public <T> T waitFor(Supplier<T> condition) {
     throw new UtamCoreError(ERR_UNSUPPORTED_METHOD);
   }
+
+  @Override
+  public <T> T waitFor(Supplier<T> condition, String errorMessage) {
+    throw new UtamCoreError(ERR_UNSUPPORTED_METHOD);
+  }
 }

--- a/utam-core/src/main/java/utam/core/framework/base/UtamBase.java
+++ b/utam-core/src/main/java/utam/core/framework/base/UtamBase.java
@@ -81,4 +81,15 @@ public interface UtamBase {
    * @return result of the applied expectations
    */
   <T> T waitFor(Supplier<T> condition);
+
+  /**
+   * polling wait that repeatedly applies expectations until truthy value is return (not null or
+   * boolean true)
+   *
+   * @param condition    condition to wait for
+   * @param <T>          return type
+   * @param errorMessage message used in the thrown timeout exception
+   * @return result of the applied expectations
+   */
+  <T> T waitFor(Supplier<T> condition, String errorMessage);
 }

--- a/utam-core/src/main/java/utam/core/framework/base/UtamBaseImpl.java
+++ b/utam-core/src/main/java/utam/core/framework/base/UtamBaseImpl.java
@@ -83,8 +83,13 @@ public abstract class UtamBaseImpl implements UtamBase {
 
   @Override
   public final <T> T waitFor(Supplier<T> condition) {
+    return waitFor(condition, null);
+  }
+
+  @Override
+  public <T> T waitFor(Supplier<T> condition, String errorMessage) {
     log("wait for condition");
-    return getDriver().waitFor(condition, null, null);
+    return getDriver().waitFor(condition, errorMessage, null);
   }
 
   @Override


### PR DESCRIPTION
Support for optional second parameter inside waitFor for custom error message
```json
{
  "methods": [
    {
      "name": "test",
      "compose": [
        {
          "apply": "waitFor",
          "args": [
            {
              "type" : "function",
              "predicate": [...]
            },
            {
              "value" : "custom error message"
            }
          ]
        }
      ]
    }
  ]
}
```