### PR TITLE
fix: remove timestamps from version javadoc tag

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
+++ b/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
@@ -45,6 +45,8 @@ import utam.core.declarative.translator.ProfileConfiguration;
 import utam.core.declarative.translator.TranslationTypesConfig;
 import utam.core.declarative.translator.TranslatorConfig;
 
+import javax.annotation.Nullable;
+
 /**
  * Instance of this type is created for every Page Object that is being translated, contains
  * reference to the Page Object context and translator context
@@ -373,6 +375,7 @@ public class TranslationContext {
    *
    * @return string
    */
+  @Nullable
   public String getConfiguredVersion() {
     return this.translatorConfiguration.getPageObjectsVersion();
   }

--- a/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
+++ b/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
@@ -45,8 +45,6 @@ import utam.core.declarative.translator.ProfileConfiguration;
 import utam.core.declarative.translator.TranslationTypesConfig;
 import utam.core.declarative.translator.TranslatorConfig;
 
-import javax.annotation.Nullable;
-
 /**
  * Instance of this type is created for every Page Object that is being translated, contains
  * reference to the Page Object context and translator context
@@ -375,7 +373,6 @@ public class TranslationContext {
    *
    * @return string
    */
-  @Nullable
   public String getConfiguredVersion() {
     return this.translatorConfiguration.getPageObjectsVersion();
   }

--- a/utam-compiler/src/main/java/utam/compiler/representation/JavadocObject.java
+++ b/utam-compiler/src/main/java/utam/compiler/representation/JavadocObject.java
@@ -133,8 +133,10 @@ public abstract class JavadocObject {
           .format("%screated from JSON %s", text.isEmpty() ? "" : ", ", sourceFileRelativePath));
       // add line @author team_name
       javadoc.add(String.format("@author %s", (author == null ? "UTAM" : author)));
-      // add line @version with timestamp
-      javadoc.add(String.format("%s %s", VERSION_TAG, version));
+      // add line @version, if not empty
+      if (version != null && !version.isEmpty()) {
+        javadoc.add(String.format("%s %s", VERSION_TAG, version));
+      }
       // add line @deprecated
       if (deprecated != null) {
         javadoc.add(String.format("@deprecated %s", deprecated));

--- a/utam-compiler/src/main/java/utam/compiler/translator/DefaultTranslatorConfiguration.java
+++ b/utam-compiler/src/main/java/utam/compiler/translator/DefaultTranslatorConfiguration.java
@@ -30,6 +30,8 @@ import utam.core.declarative.translator.TranslatorConfig;
 import utam.core.declarative.translator.TranslatorSourceConfig;
 import utam.core.declarative.translator.TranslatorTargetConfig;
 
+import javax.annotation.Nullable;
+
 /**
  * The default configuration object for executing the generator in a runner class
  *
@@ -261,7 +263,7 @@ public class DefaultTranslatorConfiguration implements TranslatorConfig {
         new ArrayList<>());
 
     final String moduleName;
-    final String pageObjectsVersion;
+    final @Nullable String pageObjectsVersion;
     final List<String> configuredCopyright;
 
     /**
@@ -272,9 +274,7 @@ public class DefaultTranslatorConfiguration implements TranslatorConfig {
     public CompilerOutputOptions(String moduleName, String pageObjectsVersion,
         List<String> configuredCopyright) {
       this.moduleName = moduleName;
-      this.pageObjectsVersion = (pageObjectsVersion == null || pageObjectsVersion.isEmpty()) ?
-          LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
-          : pageObjectsVersion;
+      this.pageObjectsVersion = (pageObjectsVersion != null && !pageObjectsVersion.isEmpty() ? pageObjectsVersion : null);
       this.configuredCopyright = configuredCopyright;
     }
   }

--- a/utam-compiler/src/main/java/utam/compiler/translator/DefaultTranslatorConfiguration.java
+++ b/utam-compiler/src/main/java/utam/compiler/translator/DefaultTranslatorConfiguration.java
@@ -30,8 +30,6 @@ import utam.core.declarative.translator.TranslatorConfig;
 import utam.core.declarative.translator.TranslatorSourceConfig;
 import utam.core.declarative.translator.TranslatorTargetConfig;
 
-import javax.annotation.Nullable;
-
 /**
  * The default configuration object for executing the generator in a runner class
  *
@@ -263,7 +261,7 @@ public class DefaultTranslatorConfiguration implements TranslatorConfig {
         new ArrayList<>());
 
     final String moduleName;
-    final @Nullable String pageObjectsVersion;
+    final String pageObjectsVersion;
     final List<String> configuredCopyright;
 
     /**
@@ -274,7 +272,7 @@ public class DefaultTranslatorConfiguration implements TranslatorConfig {
     public CompilerOutputOptions(String moduleName, String pageObjectsVersion,
         List<String> configuredCopyright) {
       this.moduleName = moduleName;
-      this.pageObjectsVersion = (pageObjectsVersion != null && !pageObjectsVersion.isEmpty() ? pageObjectsVersion : null);
+      this.pageObjectsVersion = pageObjectsVersion;
       this.configuredCopyright = configuredCopyright;
     }
   }

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamRootDescriptionTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamRootDescriptionTests.java
@@ -45,62 +45,57 @@ public class UtamRootDescriptionTests {
     PageObjectDeclaration declaration = new DeserializerUtilities().getResultFromString(json).getPageObject();
     // for interface
     List<String> description = declaration.getInterface().getDescription();
-    assertThat(description, is(hasSize(3)));
-    assertThat(declaration.getInterface().getDescription(), is(hasSize(3)));
+    assertThat(description, is(hasSize(2)));
+    assertThat(declaration.getInterface().getDescription(), is(hasSize(2)));
     assertThat(description.get(0), containsString("created from JSON"));
     assertThat(description.get(1), containsString("@author UTAM"));
-    assertThat(description.get(2), containsString(VERSION_TAG));
 
     // for impl
     description = declaration.getImplementation().getDescription();
-    assertThat(description, is(hasSize(3)));
-    assertThat(declaration.getInterface().getDescription(), is(hasSize(3)));
+    assertThat(description, is(hasSize(2)));
+    assertThat(declaration.getInterface().getDescription(), is(hasSize(2)));
     assertThat(description.get(0), containsString("created from JSON"));
     assertThat(description.get(1), containsString("@author UTAM"));
-    assertThat(description.get(2), containsString(VERSION_TAG));
   }
 
   @Test
   public void testDescriptionString() {
     // for interface
     List<String> description = getInterfaceDescription("generated/comments/verboseString.utam");
-    assertThat(description, hasSize(4));
+    assertThat(description, hasSize(3));
     assertThat(description.get(0),
         containsString("Declarative programming is a high-level programming concept"));
     assertThat(description.get(1), containsString("created from JSON"));
     assertThat(description.get(2), containsString("@author UTAM"));
-    assertThat(description.get(3), containsString(VERSION_TAG));
 
     // for impl
     description = getImplementationDescription("generated/comments/verboseString.utam");
+    assertThat(description, hasSize(3));
     assertThat(description.get(0),
         containsString("Declarative programming is a high-level programming concept"));
     assertThat(description.get(1), containsString("created from JSON"));
     assertThat(description.get(2), containsString("@author UTAM"));
-    assertThat(description.get(3), containsString(VERSION_TAG));
   }
 
   @Test
   public void testDescriptionObject() {
     // for interface
     List<String> description = getInterfaceDescription("generated/comments/verboseObject.utam");
-    assertThat(description, hasSize(6));
+    assertThat(description, hasSize(5));
     assertThat(description.get(0), containsString("one"));
     assertThat(description.get(1), containsString("<two> & */"));
     assertThat(description.get(2), containsString("created from JSON"));
     assertThat(description.get(3), containsString("@author records_team"));
-    assertThat(description.get(4), containsString(VERSION_TAG));
-    assertThat(description.get(5), containsString("@deprecated this class is outdated"));
+    assertThat(description.get(4), containsString("@deprecated this class is outdated"));
 
     // for impl
     description = getImplementationDescription("generated/comments/verboseObject.utam");
-    assertThat(description, hasSize(6));
+    assertThat(description, hasSize(5));
     assertThat(description.get(0), containsString("one"));
     assertThat(description.get(1), containsString("<two> & */"));
     assertThat(description.get(2), containsString("created from JSON"));
     assertThat(description.get(3), containsString("@author records_team"));
-    assertThat(description.get(4), containsString(VERSION_TAG));
-    assertThat(description.get(5), containsString("@deprecated this class is outdated"));
+    assertThat(description.get(4), containsString("@deprecated this class is outdated"));
   }
 
   @Test
@@ -137,12 +132,11 @@ public class UtamRootDescriptionTests {
   @Test
   public void testDescriptionObjectForInterfaceWithoutAuthor() {
     List<String> description = getInterfaceDescription("generated/comments/verboseInterface.utam");
-    assertThat(description, hasSize(5));
+    assertThat(description, hasSize(4));
     assertThat(description.get(0), containsString("description"));
     assertThat(description.get(1), containsString("created from JSON"));
     assertThat(description.get(2), containsString("@author UTAM"));
-    assertThat(description.get(3), containsString(VERSION_TAG));
-    assertThat(description.get(4), containsString("@deprecated this class is outdated"));
+    assertThat(description.get(3), containsString("@deprecated this class is outdated"));
   }
 
   @Test

--- a/utam-compiler/src/test/java/utam/compiler/translator/DefaultTranslatorConfigurationTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/translator/DefaultTranslatorConfigurationTests.java
@@ -56,5 +56,6 @@ public class DefaultTranslatorConfigurationTests {
     List<String> copyright = config.getCopyright();
     assertThat(copyright, hasSize(1));
     assertThat(copyright.get(0), is(equalTo("copyright")));
+    assertThat(config.getPageObjectsVersion(), equalTo("version"));
   }
 }

--- a/utam-compiler/src/test/java/utam/compiler/translator/JsonCompilerConfigTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/translator/JsonCompilerConfigTests.java
@@ -9,6 +9,7 @@ package utam.compiler.translator;
 
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
@@ -236,7 +237,7 @@ public class JsonCompilerConfigTests {
         new File(System.getProperty("user.dir")),
         null);
     assertThat(config.getModuleName(), is(emptyString()));
-    assertThat(config.getVersion(), startsWith(String.valueOf(LocalDate.now().getYear())));
+    assertThat(config.getVersion(), is(nullValue()));
     assertThat(config.getCopyright(), is(empty()));
 
     Module module = config.getModule();

--- a/utam-compiler/src/test/java/utam/compiler/translator/JsonCompilerConfigTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/translator/JsonCompilerConfigTests.java
@@ -9,7 +9,6 @@ package utam.compiler.translator;
 
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
@@ -237,7 +236,7 @@ public class JsonCompilerConfigTests {
         new File(System.getProperty("user.dir")),
         null);
     assertThat(config.getModuleName(), is(emptyString()));
-    assertThat(config.getVersion(), is(nullValue()));
+    assertThat(config.getVersion(), is(emptyString()));
     assertThat(config.getCopyright(), is(empty()));
 
     Module module = config.getModule();

--- a/utam-core/src/main/java/utam/core/declarative/translator/TranslatorConfig.java
+++ b/utam-core/src/main/java/utam/core/declarative/translator/TranslatorConfig.java
@@ -13,8 +13,6 @@ import java.util.List;
 import utam.core.declarative.errors.CompilerErrorsConfig;
 import utam.core.declarative.lint.LintingConfig;
 
-import javax.annotation.Nullable;
-
 /**
  * configuration for translator
  *
@@ -61,9 +59,9 @@ public interface TranslatorConfig {
   /**
    * version of the page objects to add to the JavaDoc
    *
-   * @return Version, if available
+   * @return Version, if available. It could be empty.
    */
-  @Nullable String getPageObjectsVersion();
+  String getPageObjectsVersion();
 
   /**
    * if configured, page object code can have copyright header

--- a/utam-core/src/main/java/utam/core/declarative/translator/TranslatorConfig.java
+++ b/utam-core/src/main/java/utam/core/declarative/translator/TranslatorConfig.java
@@ -13,6 +13,8 @@ import java.util.List;
 import utam.core.declarative.errors.CompilerErrorsConfig;
 import utam.core.declarative.lint.LintingConfig;
 
+import javax.annotation.Nullable;
+
 /**
  * configuration for translator
  *
@@ -59,9 +61,9 @@ public interface TranslatorConfig {
   /**
    * version of the page objects to add to the JavaDoc
    *
-   * @return not nullable string
+   * @return Version, if available
    */
-  String getPageObjectsVersion();
+  @Nullable String getPageObjectsVersion();
 
   /**
    * if configured, page object code can have copyright header


### PR DESCRIPTION
When the date and time is used as the version, the output files are rarely up-to-date. The outputs should only change when the declared inputs change.

Work: @W-12992962