### PR TITLE
fix: do not write linting report by default

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
@@ -163,7 +163,7 @@ public class LintingConfigJson implements LintingConfig {
 
   @Override
   public void writeReport(LintingContext context, String compilerRoot) {
-    if(!isDisabled && lintingOutputFile!=null) {
+    if (!isDisabled && lintingOutputFile != null) {
       String reportFilePath = getSarifFilePath(compilerRoot);
       try {
         Writer writer = getWriterWithDir(reportFilePath);

--- a/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
@@ -49,10 +49,6 @@ public class LintingConfigJson implements LintingConfig {
 
   private static final String LINTING_EXCEPTION_PREFIX = "UTAM linting failures:\n";
   /**
-   * default name for output sarif report
-   */
-  private static final String DEFAULT_SARIF_OUTPUT_FILE = "utam-lint.sarif";
-  /**
    * default configuration when config is empty, public because used from different package by
    * runner
    */
@@ -60,7 +56,7 @@ public class LintingConfigJson implements LintingConfig {
       false,
       false,
       null,
-      DEFAULT_SARIF_OUTPUT_FILE,
+      null,
       null,
       null,
       null,
@@ -93,7 +89,7 @@ public class LintingConfigJson implements LintingConfig {
       @JsonProperty(value = "elementCantHaveRootSelector") LintRuleOverride rootSelectorExists,
       @JsonProperty(value = "duplicateCustomSelectors") LintRuleOverride customWrongType) {
     this.isDisabled = requireNonNullElse(isDisabled, false);
-    this.lintingOutputFile = requireNonNullElse(lintingOutputFile, DEFAULT_SARIF_OUTPUT_FILE);
+    this.lintingOutputFile = lintingOutputFile;
     this.isInterruptCompilation = requireNonNullElse(interruptCompilation, false);
     this.isPrintToConsole = requireNonNullElse(isPrintToConsole, true);
     localRules.add(new UniqueSelectorInsidePageObject(uniqueSelectors));
@@ -167,7 +163,7 @@ public class LintingConfigJson implements LintingConfig {
 
   @Override
   public void writeReport(LintingContext context, String compilerRoot) {
-    if(!isDisabled) {
+    if(!isDisabled && lintingOutputFile!=null) {
       String reportFilePath = getSarifFilePath(compilerRoot);
       try {
         Writer writer = getWriterWithDir(reportFilePath);
@@ -186,11 +182,10 @@ public class LintingConfigJson implements LintingConfig {
   }
 
   private String getSarifFilePath(String compilerRoot) {
-    String fileName = Objects.requireNonNullElse(lintingOutputFile, DEFAULT_SARIF_OUTPUT_FILE);
     String targetPath = compilerRoot == null ? System.getProperty("user.dir") : compilerRoot;
     return
-        targetPath.endsWith(File.separator) ? targetPath + fileName
-            : targetPath + File.separator + fileName;
+        targetPath.endsWith(File.separator) ? targetPath + lintingOutputFile
+            : targetPath + File.separator + lintingOutputFile;
   }
 
   private String reportToConsole(List<LintingError> errors) {

--- a/utam-compiler/src/test/java/utam/compiler/lint/LintingConfigJsonTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/lint/LintingConfigJsonTests.java
@@ -74,6 +74,15 @@ public class LintingConfigJsonTests {
 
   @Test
   public void testDoNotProduceSarifReport() {
+    TranslatorRunner runner = getRunner("report");
+    runner.run();
+    String outputFile =
+        System.getProperty("user.dir") + "/src/test/resources/lint/ignore/utam-lint.sarif";
+    assertThat(new File(outputFile).exists(), is(false));
+  }
+
+  @Test
+  public void testLintingDisabled() {
     TranslatorRunner runner = getRunner("ignore");
     runner.run();
     String outputFile =

--- a/utam-compiler/src/test/resources/lint/changeDefaultConfig/config.json
+++ b/utam-compiler/src/test/resources/lint/changeDefaultConfig/config.json
@@ -4,6 +4,7 @@
   "resourcesOutputDir": "",
   "lint": {
     "lintingOutputFile": "test.sarif.json",
+    "writeSarifReport": true,
     "requiredRootDescription": {
       "violation": "error"
     },

--- a/utam-compiler/src/test/resources/lint/changeGlobalRules/config.json
+++ b/utam-compiler/src/test/resources/lint/changeGlobalRules/config.json
@@ -3,6 +3,7 @@
   "pageObjectsOutputDir": "",
   "resourcesOutputDir": "",
   "lint": {
+    "lintingOutputFile": "utam-lint.sarif",
     "duplicateRootSelectors": {
       "violation" : "warning",
       "exclude": [

--- a/utam-compiler/src/test/resources/lint/changeGlobalRules/config.json
+++ b/utam-compiler/src/test/resources/lint/changeGlobalRules/config.json
@@ -3,7 +3,7 @@
   "pageObjectsOutputDir": "",
   "resourcesOutputDir": "",
   "lint": {
-    "lintingOutputFile": "utam-lint.sarif",
+    "writeSarifReport": true,
     "duplicateRootSelectors": {
       "violation" : "warning",
       "exclude": [

--- a/utam-compiler/src/test/resources/lint/report/config.json
+++ b/utam-compiler/src/test/resources/lint/report/config.json
@@ -1,0 +1,8 @@
+{
+  "pageObjectsRootDir": "",
+  "pageObjectsOutputDir": "",
+  "resourcesOutputDir": "",
+  "lint": {
+    "disable": true
+  }
+}

--- a/utam-compiler/src/test/resources/lint/report/config.json
+++ b/utam-compiler/src/test/resources/lint/report/config.json
@@ -1,5 +1,8 @@
 {
   "pageObjectsRootDir": "",
   "pageObjectsOutputDir": "",
-  "resourcesOutputDir": ""
+  "resourcesOutputDir": "",
+  "lint" : {
+    "lintingOutputFile": "utam-lint.sarif"
+  }
 }

--- a/utam-compiler/src/test/resources/lint/report/config.json
+++ b/utam-compiler/src/test/resources/lint/report/config.json
@@ -1,8 +1,5 @@
 {
   "pageObjectsRootDir": "",
   "pageObjectsOutputDir": "",
-  "resourcesOutputDir": "",
-  "lint": {
-    "disable": true
-  }
+  "resourcesOutputDir": ""
 }

--- a/utam-compiler/src/test/resources/lint/report/test.utam.json
+++ b/utam-compiler/src/test/resources/lint/report/test.utam.json
@@ -1,0 +1,21 @@
+{
+  "root": true,
+  "selector": {
+    "css": "css"
+  },
+  "description": "text",
+  "elements": [
+    {
+      "name": "one",
+      "selector": {
+        "css": ".one"
+      }
+    },
+    {
+      "name": "two",
+      "selector": {
+        "css": ".one"
+      }
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/lint/sarif/config.json
+++ b/utam-compiler/src/test/resources/lint/sarif/config.json
@@ -3,6 +3,7 @@
   "pageObjectsOutputDir": "",
   "resourcesOutputDir": "",
   "lint" : {
+    "writeSarifReport": true,
     "lintingOutputFile": "../sarif.json"
   }
 }


### PR DESCRIPTION
if `writeSarifReport` is not set in compiler config, skip writing lint report