### PR TITLE
feat: Add configurable lint rule for metadata object

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamMetadata.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamMetadata.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root
+ * or https://opensource.org/licenses/MIT
+ */
 package utam.compiler.grammar;
 
 import static utam.compiler.diagnostics.ValidationUtilities.VALIDATION;
@@ -8,10 +15,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.Map;
 
-public class UtamMetadata {
+/**
+ * Page Object metadata object.
+ *
+ * @author james.evans
+ * @since 248
+ */
+class UtamMetadata {
 
-  private Map<String, Object> metadataProperties;
+  private final Map<String, Object> metadataProperties;
 
+  /**
+   * Initializes a new instance of the UtamMetadata class.
+   *
+   * @param metadataNode the node in the JSON representing the metadata object
+   */
   UtamMetadata(JsonNode metadataNode) {
     // Turn the metadata properties from a JsonNode to a POJO map
     // with String keys and Object values.
@@ -19,18 +37,20 @@ public class UtamMetadata {
         metadataNode, new TypeReference<HashMap<String, Object>>() {});
   }
 
-  public boolean hasProperty(String propertyName) {
-    return this.metadataProperties.containsKey(propertyName);
+  /**
+   * Gets the properties and values of the metadata object.
+   * @return a map with string keys and object values representing the metadata object properties
+   */
+  public Map<String, Object> getMetadataProperties() {
+    return this.metadataProperties;
   }
 
-  public Object getPropertyValue(String propertyName) {
-    if (!hasProperty(propertyName)) {
-      return null;
-    }
-
-    return this.metadataProperties.get(propertyName);
-  }
-
+  /**
+   * Processes a JSON node into a UtamMetadata object.
+   *
+   * @param node the JSON node to process
+   * @return the UtamMetadata object, if any; otherwise null
+   */
   static UtamMetadata processMetadataNode(JsonNode node) {
     VALIDATION.validateIsObject(node, "page object root", "property \"metadata\"");
     if (node == null || node.isNull()) {

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamMetadata.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamMetadata.java
@@ -1,0 +1,41 @@
+package utam.compiler.grammar;
+
+import static utam.compiler.diagnostics.ValidationUtilities.VALIDATION;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+
+public class UtamMetadata {
+
+  private Map<String, Object> metadataProperties;
+
+  UtamMetadata(JsonNode metadataNode) {
+    // Turn the metadata properties from a JsonNode to a POJO map
+    // with String keys and Object values.
+    this.metadataProperties = new ObjectMapper().convertValue(
+        metadataNode, new TypeReference<HashMap<String, Object>>() {});
+  }
+
+  public boolean hasProperty(String propertyName) {
+    return this.metadataProperties.containsKey(propertyName);
+  }
+
+  public Object getPropertyValue(String propertyName) {
+    if (!hasProperty(propertyName)) {
+      return null;
+    }
+
+    return this.metadataProperties.get(propertyName);
+  }
+
+  static UtamMetadata processMetadataNode(JsonNode node) {
+    VALIDATION.validateIsObject(node, "page object root", "property \"metadata\"");
+    if (node == null || node.isNull()) {
+      return null;
+    }
+    return new UtamMetadata(node);
+  }
+}

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamPageObject.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamPageObject.java
@@ -227,7 +227,7 @@ final class UtamPageObject {
         rootElementMethod);
     context.setElement(rootElement, null);
     ElementSelector rootSelector = rootLocator != null? new ElementSelector(rootLocator, false) : null;
-    Metadata metadataLinting = this.metadata != null ? new Metadata(this.metadata) : null;
+    Metadata metadataLinting = this.metadata != null ? new Metadata(this.metadata.getMetadataProperties()) : null;
     RootLinting rootLintingContext = new Root(!description.isEmpty(), description.hasAuthor(), rootSelector, metadataLinting);
     context.getLintingObject().setRootContext(rootLintingContext);
     return rootElement;

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamPageObject.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamPageObject.java
@@ -13,6 +13,7 @@ import static utam.compiler.grammar.JsonDeserializer.nodeToString;
 import static utam.compiler.grammar.UtamComposeMethod.getComposeStatements;
 import static utam.compiler.grammar.UtamComposeMethod.processComposeNodes;
 import static utam.compiler.grammar.UtamElement.processElementsNode;
+import static utam.compiler.grammar.UtamMetadata.processMetadataNode;
 import static utam.compiler.grammar.UtamMethod.processMethodsNode;
 import static utam.compiler.grammar.UtamProfile.processProfileNodes;
 import static utam.compiler.grammar.UtamRootDescription.processRootDescriptionNode;
@@ -35,6 +36,7 @@ import utam.compiler.helpers.MethodContext;
 import utam.compiler.helpers.TranslationContext;
 import utam.compiler.helpers.TypeUtilities.FromClass;
 import utam.compiler.lint.PageObjectLintingImpl.ElementSelector;
+import utam.compiler.lint.PageObjectLintingImpl.Metadata;
 import utam.compiler.lint.PageObjectLintingImpl.Method;
 import utam.compiler.lint.PageObjectLintingImpl.Root;
 import utam.compiler.representation.BeforeLoadMethod;
@@ -82,6 +84,7 @@ final class UtamPageObject {
   private final List<UtamMethod> methods;
   private final List<UtamElement> elements;
   private final UtamShadowElement shadow;
+  private final UtamMetadata metadata;
 
   @JsonCreator
   UtamPageObject(
@@ -128,7 +131,7 @@ final class UtamPageObject {
         : processComposeNodes(BEFORE_LOAD_METHOD_NAME, beforeLoadNode);
     this.rootLocator = processRootSelectorNode(selectorNode);
     this.description = processRootDescriptionNode(descriptionNode);
-    VALIDATION.validateIsObject(metadata, "page object root", "property \"metadata\"");
+    this.metadata = processMetadataNode(metadata);
   }
 
   private void validateAbstract() {
@@ -224,7 +227,8 @@ final class UtamPageObject {
         rootElementMethod);
     context.setElement(rootElement, null);
     ElementSelector rootSelector = rootLocator != null? new ElementSelector(rootLocator, false) : null;
-    RootLinting rootLintingContext = new Root(!description.isEmpty(), description.hasAuthor(), rootSelector);
+    Metadata metadataLinting = this.metadata != null ? new Metadata(this.metadata) : null;
+    RootLinting rootLintingContext = new Root(!description.isEmpty(), description.hasAuthor(), rootSelector, metadataLinting);
     context.getLintingObject().setRootContext(rootLintingContext);
     return rootElement;
   }

--- a/utam-compiler/src/main/java/utam/compiler/lint/JsonLintRulesConfig.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/JsonLintRulesConfig.java
@@ -9,6 +9,8 @@ package utam.compiler.lint;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import java.net.URL;
@@ -90,12 +92,28 @@ class JsonLintRulesConfig {
   static class LintRuleOverride {
     final Set<String> exceptions;
     final ViolationLevel violationLevel;
+    final AdditionalLintRuleOverrideConfigValues additionalConfig;
     @JsonCreator
     LintRuleOverride(
         @JsonProperty(value = "violation") ViolationLevel violationLevel,
-        @JsonProperty(value = "exclude") Set<String> exceptions) {
+        @JsonProperty(value = "exclude") Set<String> exceptions,
+        @JsonProperty(value = "additionalConfiguration") JsonNode additionalConfig) {
       this.exceptions = Objects.requireNonNullElse(exceptions, new HashSet<>());
       this.violationLevel = Objects.requireNonNullElse(violationLevel, ViolationLevel.warning);
+      this.additionalConfig = additionalConfig != null ? new AdditionalLintRuleOverrideConfigValues(additionalConfig) : null;
+    }
+  }
+
+  static class AdditionalLintRuleOverrideConfigValues {
+    final Map<String, Object> additionalConfigValues;
+
+    public AdditionalLintRuleOverrideConfigValues(JsonNode node) {
+      this.additionalConfigValues = new ObjectMapper().convertValue(
+          node, new TypeReference<HashMap<String, Object>>() {});
+    }
+
+    public Map<String, Object> getAdditionalConfigValues() {
+      return this.additionalConfigValues;
     }
   }
 }

--- a/utam-compiler/src/main/java/utam/compiler/lint/JsonLintRulesConfig.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/JsonLintRulesConfig.java
@@ -100,20 +100,21 @@ class JsonLintRulesConfig {
         @JsonProperty(value = "additionalConfiguration") JsonNode additionalConfig) {
       this.exceptions = Objects.requireNonNullElse(exceptions, new HashSet<>());
       this.violationLevel = Objects.requireNonNullElse(violationLevel, ViolationLevel.warning);
-      this.additionalConfig = additionalConfig != null ? new AdditionalLintRuleOverrideConfigValues(additionalConfig) : null;
+      this.additionalConfig =
+          additionalConfig != null ? new AdditionalLintRuleOverrideConfigValues(additionalConfig) : null;
     }
   }
 
   static class AdditionalLintRuleOverrideConfigValues {
     final Map<String, Object> additionalConfigValues;
 
-    public AdditionalLintRuleOverrideConfigValues(JsonNode node) {
-      this.additionalConfigValues = new ObjectMapper().convertValue(
-          node, new TypeReference<HashMap<String, Object>>() {});
+    AdditionalLintRuleOverrideConfigValues(JsonNode node) {
+      this.additionalConfigValues = new ObjectMapper().convertValue(node,
+          new TypeReference<HashMap<String, Object>>() {});
     }
 
-    public Map<String, Object> getAdditionalConfigValues() {
-      return this.additionalConfigValues;
+    Object getAdditionalConfigValue(String configValueName) {
+      return this.additionalConfigValues.getOrDefault(configValueName, null);
     }
   }
 }

--- a/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import utam.compiler.lint.JsonLintRulesConfig.LintRuleOverride;
 import utam.compiler.lint.LintingRuleImpl.ElementsWithDifferentTypes;
 import utam.compiler.lint.LintingRuleImpl.RequiredAuthor;
+import utam.compiler.lint.LintingRuleImpl.RequiredMetadata;
 import utam.compiler.lint.LintingRuleImpl.RequiredMethodDescription;
 import utam.compiler.lint.LintingRuleImpl.RequiredRootDescription;
 import utam.compiler.lint.LintingRuleImpl.RootSelectorExistsForElement;
@@ -65,6 +66,7 @@ public class LintingConfigJson implements LintingConfig {
       null,
       null,
       null,
+      null,
       null
   );
   private final List<LintingRuleImpl> localRules = new ArrayList<>();
@@ -86,7 +88,8 @@ public class LintingConfigJson implements LintingConfig {
       @JsonProperty(value = "requiredSingleShadowRoot") LintRuleOverride singleShadowBoundaryAllowed,
       @JsonProperty(value = "duplicateRootSelectors") LintRuleOverride uniqueRootSelectors,
       @JsonProperty(value = "elementCantHaveRootSelector") LintRuleOverride rootSelectorExists,
-      @JsonProperty(value = "duplicateCustomSelectors") LintRuleOverride customWrongType) {
+      @JsonProperty(value = "duplicateCustomSelectors") LintRuleOverride customWrongType,
+      @JsonProperty(value = "requiredMetadata") LintRuleOverride requiredMetadata) {
     this.isDisabled = requireNonNullElse(isDisabled, false);
     this.lintingOutputFile = requireNonNullElse(lintingOutputFile, DEFAULT_SARIF_OUTPUT_FILE);
     this.isInterruptCompilation = requireNonNullElse(interruptCompilation, false);
@@ -95,6 +98,7 @@ public class LintingConfigJson implements LintingConfig {
     localRules.add(new RequiredAuthor(requiredAuthor));
     localRules.add(new RequiredMethodDescription(requiredMethodDescription));
     localRules.add(new SingleShadowBoundaryAllowed(singleShadowBoundaryAllowed));
+    localRules.add(new RequiredMetadata(requiredMetadata));
     globalRules.add(new UniqueRootSelector(uniqueRootSelectors));
     globalRules.add(new RootSelectorExistsForElement(rootSelectorExists));
     globalRules.add(new ElementsWithDifferentTypes(customWrongType));

--- a/utam-compiler/src/main/java/utam/compiler/lint/LintingRuleImpl.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/LintingRuleImpl.java
@@ -248,11 +248,9 @@ abstract class LintingRuleImpl implements LintingRule {
 
     RequiredMetadata(LintRuleOverride override) {
       super("ULR09", override);
-      if (override != null && override.additionalConfig != null && override.additionalConfig.getAdditionalConfigValues().containsKey("requiredProperties")) {
-        this.requiredProperties = (List<Object>)override.additionalConfig.getAdditionalConfigValues().get("requiredProperties");
-      } else {
-        this.requiredProperties = null;
-      }
+      this.requiredProperties =
+          override == null || override.additionalConfig == null ? null :
+              (List<Object>)override.additionalConfig.getAdditionalConfigValue("requiredProperties");
     }
 
     @Override

--- a/utam-compiler/src/main/java/utam/compiler/lint/PageObjectLintingImpl.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/PageObjectLintingImpl.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
+import utam.compiler.grammar.UtamMetadata;
 import utam.core.declarative.lint.PageObjectLinting;
 import utam.core.declarative.representation.TypeProvider;
 import utam.core.element.Locator;
@@ -250,6 +251,31 @@ public class PageObjectLintingImpl implements PageObjectLinting {
   }
 
   /**
+   * Metadata object information for linting
+   *
+   * @author james.evans
+   * @since 248
+   */
+  public static class Metadata implements MetadataLinting {
+
+    private final UtamMetadata metadata;
+
+    public Metadata(UtamMetadata metadata) {
+      this.metadata = metadata;
+    }
+
+    @Override
+    public boolean hasMetadataProperty(String propertyName) {
+      return metadata.hasProperty(propertyName);
+    }
+
+    @Override
+    public Object getMetadataPropertyValue(String propertyName) {
+      return metadata.getPropertyValue(propertyName);
+    }
+  }
+
+  /**
    * Root information for linting
    *
    * @author elizaveta.ivanova
@@ -260,11 +286,13 @@ public class PageObjectLintingImpl implements PageObjectLinting {
     private final boolean hasRootDescription;
     private final boolean hasAuthor;
     private final Element element;
+    private final Metadata metadata;
 
-    public Root(boolean hasRootDescription, boolean hasAuthor, ElementSelector selector) {
+    public Root(boolean hasRootDescription, boolean hasAuthor, ElementSelector selector, Metadata metadata) {
       this.hasRootDescription = hasRootDescription;
       this.hasAuthor = hasAuthor;
       this.element = selector == null ? null : new Element("root", null, selector, null);
+      this.metadata = metadata;
     }
 
     @Override
@@ -280,6 +308,16 @@ public class PageObjectLintingImpl implements PageObjectLinting {
     @Override
     public ElementLinting getRootElement() {
       return element;
+    }
+
+    @Override
+    public MetadataLinting getMetadata() {
+      return this.metadata;
+    }
+
+    @Override
+    public boolean hasMetadata() {
+      return this.metadata != null;
     }
 
     @Override

--- a/utam-compiler/src/main/java/utam/compiler/lint/PageObjectLintingImpl.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/PageObjectLintingImpl.java
@@ -11,9 +11,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-import utam.compiler.grammar.UtamMetadata;
 import utam.core.declarative.lint.PageObjectLinting;
 import utam.core.declarative.representation.TypeProvider;
 import utam.core.element.Locator;
@@ -258,20 +258,23 @@ public class PageObjectLintingImpl implements PageObjectLinting {
    */
   public static class Metadata implements MetadataLinting {
 
-    private final UtamMetadata metadata;
+    private final Map<String, Object> metadataProperties;
 
-    public Metadata(UtamMetadata metadata) {
-      this.metadata = metadata;
+    public Metadata(Map<String, Object> metadata) {
+      this.metadataProperties = metadata;
     }
 
     @Override
     public boolean hasMetadataProperty(String propertyName) {
-      return metadata.hasProperty(propertyName);
+      return metadataProperties.containsKey(propertyName);
     }
 
     @Override
     public Object getMetadataPropertyValue(String propertyName) {
-      return metadata.getPropertyValue(propertyName);
+      if (!this.metadataProperties.containsKey(propertyName)) {
+        return null;
+      }
+      return metadataProperties.get(propertyName);
     }
   }
 

--- a/utam-compiler/src/main/resources/errors.config.json
+++ b/utam-compiler/src/main/resources/errors.config.json
@@ -378,6 +378,10 @@
     "message": "property \"author\" is missing in the root description"
   },
   {
+    "code": 2006,
+    "message": "property \"metadata\" is missing or misconfigured in the root"
+  },
+  {
     "code": 3001,
     "message": "same root selector \"%s\" is used as a root selector in the page object %s"
   },
@@ -388,9 +392,5 @@
   {
     "code": 3003,
     "message": "custom selector \"%s\" of the element \"%s\" is used for an element \"%s\" in the page object %s, but has a different type \"%s\""
-  },
-  {
-    "code": 4001,
-    "message": "property \"metadata\" is missing or misconfigured in the root"
   }
 ]

--- a/utam-compiler/src/main/resources/errors.config.json
+++ b/utam-compiler/src/main/resources/errors.config.json
@@ -388,5 +388,9 @@
   {
     "code": 3003,
     "message": "custom selector \"%s\" of the element \"%s\" is used for an element \"%s\" in the page object %s, but has a different type \"%s\""
+  },
+  {
+    "code": 4001,
+    "message": "property \"metadata\" is missing or misconfigured in the root"
   }
 ]

--- a/utam-compiler/src/main/resources/rules.config.json
+++ b/utam-compiler/src/main/resources/rules.config.json
@@ -62,5 +62,13 @@
         "description": "Element with custom tag should have same type across all page objects",
         "help": "change the element \"%s\" type to the same type as the element \"%s\" in page object \"%s\"",
         "violation": "warning"
+    },
+    {
+        "ruleId": "ULR09",
+        "errorCode": 4001,
+        "name": "Required metadata property",
+        "description": "Check page object contains a metadata property with proper structure",
+        "help": "add \"metadata\" property whose value is a non-empty object to the root",
+        "violation": "disabled"
     }
 ]

--- a/utam-compiler/src/main/resources/rules.config.json
+++ b/utam-compiler/src/main/resources/rules.config.json
@@ -65,7 +65,7 @@
     },
     {
         "ruleId": "ULR09",
-        "errorCode": 4001,
+        "errorCode": 2006,
         "name": "Required metadata property",
         "description": "Check page object contains a metadata property with proper structure",
         "help": "add \"metadata\" property whose value is a non-empty object to the root",

--- a/utam-compiler/src/test/java/utam/compiler/lint/LintingRuleTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/lint/LintingRuleTests.java
@@ -283,7 +283,7 @@ public class LintingRuleTests {
     List<LintingError> errors = test(linting, files);
     assertThat(errors, hasSize(1));
     assertThat(errors.get(0).getFullMessage(),
-        equalTo("lint rule ULR09 failure in page object test/lint/metadata/pageWithoutMetadata: warning 4001: "
+        equalTo("lint rule ULR09 failure in page object test/lint/metadata/pageWithoutMetadata: warning 2006: "
             + "property \"metadata\" is missing or misconfigured in the root; add \"metadata\" "
             + "property whose value is a non-empty object to the root"));
   }
@@ -307,7 +307,7 @@ public class LintingRuleTests {
     List<LintingError> errors = test(linting, files);
     assertThat(errors, hasSize(1));
     assertThat(errors.get(0).getFullMessage(),
-        equalTo("lint rule ULR09 failure in page object test/lint/metadata/pageWithMissingMetadataProperty: warning 4001: "
+        equalTo("lint rule ULR09 failure in page object test/lint/metadata/pageWithMissingMetadataProperty: warning 2006: "
             + "property \"metadata\" is missing or misconfigured in the root; add a property named "
             + "\"status\" to the metadata object in the page object"));
   }
@@ -321,7 +321,7 @@ public class LintingRuleTests {
     List<LintingError> errors = test(linting, files);
     assertThat(errors, hasSize(1));
     assertThat(errors.get(0).getFullMessage(),
-        equalTo("lint rule ULR09 failure in page object test/lint/metadata/pageWithInvalidMetadataProperty: warning 4001: "
+        equalTo("lint rule ULR09 failure in page object test/lint/metadata/pageWithInvalidMetadataProperty: warning 2006: "
             + "property \"metadata\" is missing or misconfigured in the root; set the \"status\" "
             + "metadata property to one of the following values: public, internal, private"));
   }
@@ -335,7 +335,7 @@ public class LintingRuleTests {
     List<LintingError> errors = test(linting, files);
     assertThat(errors, hasSize(1));
     assertThat(errors.get(0).getFullMessage(),
-        equalTo("lint rule ULR09 failure in page object test/lint/metadata/pageWithEmptyMetadataProperty: warning 4001: "
+        equalTo("lint rule ULR09 failure in page object test/lint/metadata/pageWithEmptyMetadataProperty: warning 2006: "
             + "property \"metadata\" is missing or misconfigured in the root; set the \"scrumTeam\" "
             + "metadata property a non-empty value"));
   }

--- a/utam-compiler/src/test/java/utam/compiler/lint/SarifConverterTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/lint/SarifConverterTests.java
@@ -92,7 +92,7 @@ public class SarifConverterTests {
     assertThat(toolComponent.getName(), equalTo(SARIF_NAME));
     assertThat(toolComponent.getInformationUri(), equalTo(SARIF_INFORMATION_URI));
     assertThat(toolComponent.getSemanticVersion(), equalTo(SARIF_SEMANTIC_VERSION.value()));
-    assertThat(toolComponent.getRules(), hasSize(8));
+    assertThat(toolComponent.getRules(), hasSize(9));
 
     // rule properties
     String ruleId = "ULR03";

--- a/utam-compiler/src/test/java/utam/compiler/translator/TranslatorGenerationCommandTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/translator/TranslatorGenerationCommandTests.java
@@ -90,7 +90,7 @@ public class TranslatorGenerationCommandTests {
   @Test
   public void testJsonConfigWithOtherArgsThrows() {
     TranslatorGenerationCommand command = new TranslatorGenerationCommand();
-    command.jsonConfig = new File("utam.presence.config.json");
+    command.jsonConfig = new File("utam.config.json");
     command.inputDirectory = new File("input");
     TranslatorConfig config = command.getTranslationConfig();
     assertThat(config, is(nullValue()));

--- a/utam-compiler/src/test/java/utam/compiler/translator/TranslatorGenerationCommandTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/translator/TranslatorGenerationCommandTests.java
@@ -90,7 +90,7 @@ public class TranslatorGenerationCommandTests {
   @Test
   public void testJsonConfigWithOtherArgsThrows() {
     TranslatorGenerationCommand command = new TranslatorGenerationCommand();
-    command.jsonConfig = new File("utam.config.json");
+    command.jsonConfig = new File("utam.presence.config.json");
     command.inputDirectory = new File("input");
     TranslatorConfig config = command.getTranslationConfig();
     assertThat(config, is(nullValue()));

--- a/utam-compiler/src/test/resources/lint/metadata/pageWithEmptyMetadataProperty.json
+++ b/utam-compiler/src/test/resources/lint/metadata/pageWithEmptyMetadataProperty.json
@@ -1,0 +1,60 @@
+{
+  "metadata": {
+    "status": "public",
+    "scrumTeam": ""
+  },
+  "root": true,
+  "selector": {
+    "css": ".one"
+  },
+  "elements": [
+    {
+      "name": "one",
+      "selector": {
+        "css": ".one"
+      }
+    },
+    {
+      "name": "two",
+      "type" : "container",
+      "selector": {
+        "css": ".two"
+      }
+    },
+    {
+      "name": "three",
+      "selector": {
+        "css": ".two"
+      },
+      "shadow" : {
+        "elements" : [
+          {
+            "name": "inshadow",
+            "selector": {
+              "css": ".two"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "container1",
+      "type" : "container"
+    },
+    {
+      "name": "container2",
+      "type" : "container"
+    }
+  ],
+  "methods" : [
+    {
+      "name" : "nodescription",
+      "compose" : [
+        {
+          "element" : "root",
+          "apply" : "isPresent"
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/lint/metadata/pageWithInvalidMetadataProperty.json
+++ b/utam-compiler/src/test/resources/lint/metadata/pageWithInvalidMetadataProperty.json
@@ -1,0 +1,60 @@
+{
+  "metadata": {
+    "status": "invalid",
+    "scrumTeam": "UTAM"
+  },
+  "root": true,
+  "selector": {
+    "css": ".one"
+  },
+  "elements": [
+    {
+      "name": "one",
+      "selector": {
+        "css": ".one"
+      }
+    },
+    {
+      "name": "two",
+      "type" : "container",
+      "selector": {
+        "css": ".two"
+      }
+    },
+    {
+      "name": "three",
+      "selector": {
+        "css": ".two"
+      },
+      "shadow" : {
+        "elements" : [
+          {
+            "name": "inshadow",
+            "selector": {
+              "css": ".two"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "container1",
+      "type" : "container"
+    },
+    {
+      "name": "container2",
+      "type" : "container"
+    }
+  ],
+  "methods" : [
+    {
+      "name" : "nodescription",
+      "compose" : [
+        {
+          "element" : "root",
+          "apply" : "isPresent"
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/lint/metadata/pageWithMetadata.json
+++ b/utam-compiler/src/test/resources/lint/metadata/pageWithMetadata.json
@@ -1,0 +1,60 @@
+{
+  "metadata": {
+    "status": "internal",
+    "scrumTeam": "UTAM"
+  },
+  "root": true,
+  "selector": {
+    "css": ".one"
+  },
+  "elements": [
+    {
+      "name": "one",
+      "selector": {
+        "css": ".one"
+      }
+    },
+    {
+      "name": "two",
+      "type" : "container",
+      "selector": {
+        "css": ".two"
+      }
+    },
+    {
+      "name": "three",
+      "selector": {
+        "css": ".two"
+      },
+      "shadow" : {
+        "elements" : [
+          {
+            "name": "inshadow",
+            "selector": {
+              "css": ".two"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "container1",
+      "type" : "container"
+    },
+    {
+      "name": "container2",
+      "type" : "container"
+    }
+  ],
+  "methods" : [
+    {
+      "name" : "nodescription",
+      "compose" : [
+        {
+          "element" : "root",
+          "apply" : "isPresent"
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/lint/metadata/pageWithMissingMetadataProperty.json
+++ b/utam-compiler/src/test/resources/lint/metadata/pageWithMissingMetadataProperty.json
@@ -1,0 +1,59 @@
+{
+  "metadata": {
+    "scrumTeam": "UTAM"
+  },
+  "root": true,
+  "selector": {
+    "css": ".one"
+  },
+  "elements": [
+    {
+      "name": "one",
+      "selector": {
+        "css": ".one"
+      }
+    },
+    {
+      "name": "two",
+      "type" : "container",
+      "selector": {
+        "css": ".two"
+      }
+    },
+    {
+      "name": "three",
+      "selector": {
+        "css": ".two"
+      },
+      "shadow" : {
+        "elements" : [
+          {
+            "name": "inshadow",
+            "selector": {
+              "css": ".two"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "container1",
+      "type" : "container"
+    },
+    {
+      "name": "container2",
+      "type" : "container"
+    }
+  ],
+  "methods" : [
+    {
+      "name" : "nodescription",
+      "compose" : [
+        {
+          "element" : "root",
+          "apply" : "isPresent"
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/lint/metadata/pageWithoutMetadata.json
+++ b/utam-compiler/src/test/resources/lint/metadata/pageWithoutMetadata.json
@@ -1,0 +1,56 @@
+{
+  "root": true,
+  "selector": {
+    "css": ".one"
+  },
+  "elements": [
+    {
+      "name": "one",
+      "selector": {
+        "css": ".one"
+      }
+    },
+    {
+      "name": "two",
+      "type" : "container",
+      "selector": {
+        "css": ".two"
+      }
+    },
+    {
+      "name": "three",
+      "selector": {
+        "css": ".two"
+      },
+      "shadow" : {
+        "elements" : [
+          {
+            "name": "inshadow",
+            "selector": {
+              "css": ".two"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "container1",
+      "type" : "container"
+    },
+    {
+      "name": "container2",
+      "type" : "container"
+    }
+  ],
+  "methods" : [
+    {
+      "name" : "nodescription",
+      "compose" : [
+        {
+          "element" : "root",
+          "apply" : "isPresent"
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/lint/metadata/presence.config.json
+++ b/utam-compiler/src/test/resources/lint/metadata/presence.config.json
@@ -1,0 +1,35 @@
+{
+  "pageObjectsRootDir": "",
+  "pageObjectsOutputDir": "",
+  "resourcesOutputDir": "",
+  "lint": {
+    "lintingOutputFile": "test.sarif.json",
+    "duplicateSelectors": {
+      "violation": "disabled"
+    },
+    "requiredRootDescription": {
+      "violation": "disabled"
+    },
+    "requiredAuthor": {
+      "violation": "disabled"
+    },
+    "requiredMethodDescription": {
+      "violation": "disabled"
+    },
+    "requiredSingleShadowRoot": {
+      "violation": "disabled"
+    },
+    "duplicateRootSelectors": {
+      "violation" : "disabled"
+    },
+    "elementCantHaveRootSelector" : {
+      "violation" : "disabled"
+    },
+    "duplicateCustomSelectors": {
+      "violation" : "disabled"
+    },
+    "requiredMetadata": {
+      "violation": "warning"
+    }
+  }
+}

--- a/utam-compiler/src/test/resources/lint/metadata/structure.config.json
+++ b/utam-compiler/src/test/resources/lint/metadata/structure.config.json
@@ -1,0 +1,46 @@
+{
+  "pageObjectsRootDir": "",
+  "pageObjectsOutputDir": "",
+  "resourcesOutputDir": "",
+  "lint": {
+    "lintingOutputFile": "test.sarif.json",
+    "duplicateSelectors": {
+      "violation": "disabled"
+    },
+    "requiredRootDescription": {
+      "violation": "disabled"
+    },
+    "requiredAuthor": {
+      "violation": "disabled"
+    },
+    "requiredMethodDescription": {
+      "violation": "disabled"
+    },
+    "requiredSingleShadowRoot": {
+      "violation": "disabled"
+    },
+    "duplicateRootSelectors": {
+      "violation" : "disabled"
+    },
+    "elementCantHaveRootSelector" : {
+      "violation" : "disabled"
+    },
+    "duplicateCustomSelectors": {
+      "violation" : "disabled"
+    },
+    "requiredMetadata": {
+      "violation": "warning",
+      "additionalConfiguration": {
+        "requiredProperties": [
+          {
+            "name": "status",
+            "values": [ "public", "internal", "private" ]
+          },
+          {
+            "name": "scrumTeam"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/utam-core/src/main/java/utam/core/declarative/lint/PageObjectLinting.java
+++ b/utam-core/src/main/java/utam/core/declarative/lint/PageObjectLinting.java
@@ -153,11 +153,50 @@ public interface PageObjectLinting {
     ElementLinting getRootElement();
 
     /**
+     * Gets the metadata element from the root of the page object
+     *
+     * @return metadata element
+     */
+    MetadataLinting getMetadata();
+
+    /**
+     * Check if page object has a metadata element
+     *
+     * @return true if it does
+     */
+    boolean hasMetadata();
+
+    /**
      * Check if page object has root selector
      *
      * @return true if it does
      */
     boolean isRoot();
+  }
+
+  /**
+   * Linting information about the metadata property
+   *
+   * @author james.evans
+   * @since 248
+   */
+  interface MetadataLinting {
+
+    /**
+     * Check if value object of metadata property has a property with the given name
+     *
+     * @param propertyName the name of the property to check for
+     * @return true if the property exists in the value object of the metadata property
+     */
+    boolean hasMetadataProperty(String propertyName);
+
+    /**
+     * Gets the value of the named property from the metadata property object.
+     *
+     * @param propertyName the name of hte property for which to retrieve the value
+     * @return the value of the property if it exists, otherwise null
+     */
+    Object getMetadataPropertyValue(String propertyName);
   }
 
   /**


### PR DESCRIPTION
This PR adds a new rule for linting the metadata field (disabled by default, because it's an optional field), and can be configured in the compiler config with the following JSON:
```json
{
  "lint": {
    "requiredMetadata": {
      "violation": "warning",
      "exclude": [],
      "additionalConfiguration": {
        "requiredProperties": [
          {
            "name": "foo"
          },
          {
            "name": "bar",
            "values": [ "baz", "quux", "corge" ]
          }
        ]
      }
    }
  }
}
```
The `requiredMetadata` property without any `additionalConfiguration` entries will simply check for the presence of the `metadata` property in each page object. Within `additionalConfiguration`, the user is able to specify a `requiredProperties` list that indicates the properties that must be present in the metadata object.

An object in the `requiredProperties` array with only a `name` field will check only for the presence of the property and that its value is not empty (or only containing whitespace). One with a `values` field will check for the presence of the property, and that the value is one of the values supplied in the array.

For now, we only handle string properties and values in metadata, but this could be extended in the future to include a type property (default "string"), and can specify different metadata types and different methods of validation. See the added unit tests and the resources therein for full examples.