### PR TITLE
feat: update duplicate selector lint rule for lists

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
-import java.util.Objects;
 import utam.compiler.UtamCompilationError;
 import utam.compiler.helpers.ElementContext;
 import utam.compiler.helpers.ElementUnitTestHelper;

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
+import java.util.Objects;
 import utam.compiler.UtamCompilationError;
 import utam.compiler.helpers.ElementContext;
 import utam.compiler.helpers.ElementUnitTestHelper;
@@ -291,7 +292,8 @@ public final class UtamElement {
               scopeElement.getName(),
               isExpandScopeShadowRoot,
               isReturnList));
-      ElementSelector lintingSelector = new ElementSelector(locator, selector.isReturnAll());
+      ElementSelector lintingSelector = new ElementSelector(locator, selector.isReturnAll(),
+          filter != null ? filter.applyMethod : null, filter != null ? filterMatcher.getMatcherType() : null);
       ElementLinting lintingContext = new Element(name, elementType.getFullName(),
           lintingSelector, new ElementScope(scopeElement.getName(), isExpandScopeShadowRoot));
       context.getLintingObject().setElement(lintingContext);
@@ -381,7 +383,8 @@ public final class UtamElement {
           isExpandScopeShadowRoot,
           isList
       ));
-      ElementSelector lintingSelector = new ElementSelector(locator, selector.isReturnAll());
+      ElementSelector lintingSelector = new ElementSelector(locator, selector.isReturnAll(),
+          filter != null ? filter.applyMethod : null, filter != null ? filterMatcher.getMatcherType() : null);
       ElementLinting lintingContext = new Element(name, LINTING_BASIC_TYPE,
           lintingSelector, new ElementScope(scopeElement.getName(), isExpandScopeShadowRoot));
       context.getLintingObject().setElement(lintingContext);
@@ -431,7 +434,8 @@ public final class UtamElement {
       elementContext.setElementMethod(method, context);
       context.setElement(elementContext, null);
       context.setMethod(method);
-      ElementSelector lintingSelector = new ElementSelector(locator.getLocator(), selector.isReturnAll());
+      ElementSelector lintingSelector = new ElementSelector(locator.getLocator(),
+          selector.isReturnAll(), null, null);
       ElementLinting lintingContext = new Element(name, LINTING_CONTAINER_TYPE,
           lintingSelector, new ElementScope(scopeElement.getName(), isExpandScopeShadowRoot));
       context.getLintingObject().setElement(lintingContext);
@@ -474,7 +478,8 @@ public final class UtamElement {
       elementContext.setElementMethod(method, context);
       context.setElement(elementContext, field);
       context.setMethod(method);
-      ElementSelector lintingSelector = new ElementSelector(locator.getLocator(), selector.isReturnAll());
+      ElementSelector lintingSelector = new ElementSelector(locator.getLocator(),
+          selector.isReturnAll(), null, null);
       ElementLinting lintingContext = new Element(name, LINTING_FRAME_TYPE,
           lintingSelector, new ElementScope(scopeElement.getName(), isExpandScopeShadowRoot));
       context.getLintingObject().setElement(lintingContext);

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamPageObject.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamPageObject.java
@@ -226,7 +226,9 @@ final class UtamPageObject {
     ElementContext rootElement = new ElementContext.Root(interfaceType, rootLocator, elementType,
         rootElementMethod);
     context.setElement(rootElement, null);
-    ElementSelector rootSelector = rootLocator != null? new ElementSelector(rootLocator, false) : null;
+    ElementSelector rootSelector = rootLocator != null ?
+        new ElementSelector(rootLocator, false, null, null) :
+        null;
     Metadata metadataLinting = this.metadata != null ? new Metadata(this.metadata.getMetadataProperties()) : null;
     RootLinting rootLintingContext = new Root(!description.isEmpty(), description.hasAuthor(), rootSelector, metadataLinting);
     context.getLintingObject().setRootContext(rootLintingContext);

--- a/utam-compiler/src/test/java/utam/compiler/lint/LintingRuleTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/lint/LintingRuleTests.java
@@ -114,6 +114,16 @@ public class LintingRuleTests {
   }
 
   @Test
+  public void testListCanHaveSameSelectorWithFilters() {
+    List<LintingError> errors = test("lint/rules/listSelectorWithFilters");
+    assertThat(errors, hasSize(1));
+    assertThat(errors.get(0).getFullMessage(),
+        equalTo("lint rule ULR01 failure in page object test/lint/rules/listSelectorWithFilters: "
+            + "warning 2001: duplicate selector \"css\" for the elements \"list4\" and \"list2\"; "
+            + "remove duplicate elements: \"list2\" or \"list4\""));
+  }
+
+  @Test
   public void testRequiredDescription() {
     List<LintingError> errors = test("lint/rules/defaultConfig");
     assertThat(errors, hasSize(5));

--- a/utam-compiler/src/test/resources/lint/rules/listSelectorWithFilters.json
+++ b/utam-compiler/src/test/resources/lint/rules/listSelectorWithFilters.json
@@ -1,0 +1,87 @@
+{
+  "description": {
+    "author": "author",
+    "text": [
+      "text"
+    ]
+  },
+  "elements": [
+    {
+      "name": "single",
+      "selector": {
+        "css": "css"
+      }
+    },
+    {
+      "name": "list1",
+      "type": "my/custom/type",
+      "selector": {
+        "css": "css",
+        "returnAll" : true
+      }
+    },
+    {
+      "name": "list2",
+      "type": "my/custom/type",
+      "selector": {
+        "css": "css",
+        "returnAll" : true
+      },
+      "filter": {
+        "apply": "getText",
+        "findFirst": true,
+        "matcher": {
+          "type": "stringContains",
+          "args": [
+            {
+              "name": "text",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "list3",
+      "type": "my/custom/type",
+      "selector": {
+        "css": "css",
+        "returnAll" : true
+      },
+      "filter": {
+        "apply": "getText",
+        "findFirst": true,
+        "matcher": {
+          "type": "stringEquals",
+          "args": [
+            {
+              "name": "text",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "list4",
+      "type": "my/custom/type",
+      "selector": {
+        "css": "css",
+        "returnAll" : true
+      },
+      "filter": {
+        "apply": "getText",
+        "findFirst": true,
+        "matcher": {
+          "type": "stringContains",
+          "args": [
+            {
+              "name": "text",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This change updates the lint rule for duplicate selectors in the same page object to allow duplicates in element definitions under the following circumstances:
* One element is a list, and the other is not
* Two elements are lists, but one contains a filter and the other does not
* Two elements are lists and both contain filters, but they filter on different apply methods
* Two elements are lists and both contain filters on the same method, but use different matcher types