### PR TITLE
feat: Add load: true to the element

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamComposeMethod.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamComposeMethod.java
@@ -39,7 +39,7 @@ import utam.core.declarative.representation.TypeProvider;
 class UtamComposeMethod extends UtamMethod {
 
   private final List<UtamMethodAction> composeList;
-
+  private final boolean isPublic;
   @JsonCreator
   UtamComposeMethod(
       @JsonProperty(value = "name", required = true) String name,
@@ -48,6 +48,7 @@ class UtamComposeMethod extends UtamMethod {
       @JsonProperty("description") JsonNode descriptionNode) {
     super(name, descriptionNode, argsNode);
     this.composeList = processComposeNodes(name, composeNodes);
+    this.isPublic = true;
   }
 
   /**
@@ -58,9 +59,10 @@ class UtamComposeMethod extends UtamMethod {
    * @param compose     statements
    */
   UtamComposeMethod(String name, UtamMethodDescription description,
-      List<UtamMethodAction> compose) {
+      List<UtamMethodAction> compose, boolean isPublic) {
     super(name, description);
     this.composeList = compose;
+    this.isPublic = isPublic;
   }
 
   /**
@@ -176,7 +178,8 @@ class UtamComposeMethod extends UtamMethod {
         lastStatementReturnType,
         parameters,
         statements,
-        description
+        description,
+        isPublic
     );
   }
 }

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
@@ -83,6 +83,7 @@ public final class UtamElement {
   private final UtamElementFilter filter;
   private UtamSelector selector;
   private final Boolean isWait;
+  private final Boolean isLoad;
 
   @JsonCreator
   UtamElement(
@@ -91,6 +92,7 @@ public final class UtamElement {
       @JsonProperty(value = "public") Boolean isPublic,
       @JsonProperty(value = "nullable") Boolean isNullable,
       @JsonProperty(value = "wait") Boolean isWait,
+      @JsonProperty(value = "load") Boolean isLoad,
       @JsonProperty(value = "selector") JsonNode selectorNode,
       @JsonProperty(value = "filter") JsonNode filterNode,
       @JsonProperty("shadow") JsonNode shadowNode,
@@ -108,6 +110,7 @@ public final class UtamElement {
     this.traversal = processTypeNode(type);
     this.description = processMethodDescriptionNode(descriptionNode, validationContext);
     this.isWait = isWait;
+    this.isLoad = isLoad;
   }
 
   /**
@@ -164,16 +167,25 @@ public final class UtamElement {
   private boolean isWait() {
     return Boolean.TRUE.equals(isWait);
   }
-
+  private boolean isLoad() {
+    return Boolean.TRUE.equals(isLoad);
+  }
+  private boolean isWaitOrLoad() {return isLoad() || isWait();}
+  private boolean isPrivateWait() {return isLoad() && !isWait();}
   /**
    * Some functionality in compiler can lead to adjusting JSON itself, for example "wait"
    *
    * @param pageObject de-serialized page object
    */
   void preProcessElement(UtamPageObject pageObject) {
-    if (isWait()) {
+    if (isWaitOrLoad()) {
       UtamComposeMethod composeMethod = buildWaitForComposeMethod();
       pageObject.setComposeMethod(composeMethod);
+      //add to beforeLoad
+      if(isLoad()){
+        validateElementArgumentsForLoad();
+        pageObject.getBeforeLoad().add(buildApplyForLoad(composeMethod.name));
+      }
     }
     if (shadow != null) {
       shadow.elements.forEach(utamElement -> utamElement.preProcessElement(pageObject));
@@ -193,7 +205,30 @@ public final class UtamElement {
         null, null, null);
     List<UtamMethodAction> compose = Collections.singletonList(
         new UtamMethodActionWaitForElement(name));
-    return new UtamComposeMethod(methodName, description, compose);
+    return new UtamComposeMethod(methodName, description, compose, !isPrivateWait());
+  }
+
+  /**
+   * Element with "load" should not have parameters.
+   *
+   * @return
+   */
+  private void validateElementArgumentsForLoad() {
+    if ((selector != null && selector.hasArgsNode())
+            || (filter != null && !filter.getMatcherParameters().isEmpty()
+            || (traversal instanceof Container))) {
+      String message = VALIDATION.getErrorMessage(206, name);
+      throw new UtamCompilationError(message);
+    }
+  }
+
+  /**
+   * get apply for beforeload
+   *
+   * @return UtamComposeMethod object
+   */
+  private UtamMethodAction buildApplyForLoad(String methodName) {
+    return new UtamMethodActionApply(null, methodName, null, null, null, null, false);
   }
 
   void traverse(

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamPageObject.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamPageObject.java
@@ -86,6 +86,10 @@ final class UtamPageObject {
   private final UtamShadowElement shadow;
   private final UtamMetadata metadata;
 
+  List<UtamMethodAction> getBeforeLoad() {
+    return beforeLoad;
+  }
+
   @JsonCreator
   UtamPageObject(
       @JsonProperty(value = "implements") String implementsType,

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamSelector.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamSelector.java
@@ -164,4 +164,8 @@ class UtamSelector extends UtamRootSelector {
   boolean isReturnAll() {
     return isReturnAll;
   }
+
+  boolean hasArgsNode() {
+    return argsNode != null;
+  }
 }

--- a/utam-compiler/src/main/java/utam/compiler/representation/ComposeMethod.java
+++ b/utam-compiler/src/main/java/utam/compiler/representation/ComposeMethod.java
@@ -33,7 +33,7 @@ public class ComposeMethod implements PageObjectMethod {
   private final List<TypeProvider> imports = new ArrayList<>();
   private final TypeProvider returns;
   private final JavadocObject javadoc;
-
+  private final boolean isPublic;
   /**
    * Initializes a new instance of the ComposeMethod class
    *
@@ -65,6 +65,33 @@ public class ComposeMethod implements PageObjectMethod {
         returnType,
         parameters,
         description);
+    this.isPublic = true;
+  }
+
+  public ComposeMethod(String methodName,
+                       TypeProvider returnType,
+                       List<MethodParameter> parameters,
+                       List<ComposeMethodStatement> statements,
+                       UtamMethodDescription description,
+                       boolean isPublic) {
+    this.name = methodName;
+    this.returns = returnType;
+    statements.forEach(
+            statement -> {
+              code.addAll(statement.getCodeLines());
+              ParameterUtils.setImports(imports, statement.getImports());
+              ParameterUtils.setImports(classImports, statement.getClassImports());
+            });
+    this.parameters = new ArrayList<>(parameters);
+    if(!returnType.isSameType(VOID)) {
+      ParameterUtils.setImport(imports, returnType);
+      ParameterUtils.setImport(classImports, returnType);
+    }
+    this.javadoc = new MethodJavadoc(name,
+            returnType,
+            parameters,
+            description);
+    this.isPublic = isPublic;
   }
 
   @Override
@@ -84,7 +111,7 @@ public class ComposeMethod implements PageObjectMethod {
 
   @Override
   public boolean isPublic() {
-    return true;
+    return isPublic;
   }
 
 }

--- a/utam-compiler/src/main/resources/errors.config.json
+++ b/utam-compiler/src/main/resources/errors.config.json
@@ -125,6 +125,10 @@
     "message": "element \"%s\": only basic element can have nested elements or shadow root"
   },
   {
+    "code": 206,
+    "message": "element \"%s\": load declaration not supported for element with arguments"
+  },
+  {
     "code": 300,
     "message": "element \"%s\" filter: incorrect format of element filter",
     "docs": "https://utam.dev/grammar/spec#element-filter"

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamElementLoadTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamElementLoadTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root
+ * or https://opensource.org/licenses/MIT
+ */
+package utam.compiler.grammar;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.testng.Assert.expectThrows;
+import static utam.compiler.helpers.TypeUtilities.PAGE_OBJECT;
+import static utam.compiler.grammar.UtamPageObject.BEFORE_LOAD_METHOD_NAME;
+
+import org.testng.annotations.Test;
+import utam.compiler.UtamCompilationError;
+import utam.compiler.representation.PageObjectValidationTestHelper;
+import utam.compiler.representation.PageObjectValidationTestHelper.MethodInfo;
+import utam.compiler.representation.PageObjectValidationTestHelper.MethodParameterInfo;
+import utam.core.declarative.representation.PageObjectMethod;
+
+/**
+ * Tests for "load" inside UtamElement
+ *
+ * @author kperumal
+ * @since 250
+ */
+public class UtamElementLoadTests {
+
+    PageObjectMethod getMethod(String jsonFile, String methodName) {
+        return new DeserializerUtilities().getContext(jsonFile)
+                .getMethod(methodName);
+    }
+
+    @Test
+    public void testLoadInPrivateBasicElement() {
+        //verify private wait method is created for private element
+        String privateElementWaitMethodName = "waitForBasicPrivateElement";
+        PageObjectMethod privateElementWaitMethod = getMethod("generated/load/loadBasicPrivateElement.utam", privateElementWaitMethodName);
+        MethodInfo expectedPrivateWait = new MethodInfo(privateElementWaitMethodName, "BasicPrivateElementElement");
+        expectedPrivateWait.setNotPublic();
+        expectedPrivateWait.addCodeLine("BasicPrivateElementElement statement0 = this.waitFor(() -> {\n"
+                + "BasicPrivateElementElement pstatement0 = this.getBasicPrivateElementElement();\n"
+                + "return pstatement0;\n"
+                + "})");
+        expectedPrivateWait.addCodeLine("return statement0");
+        PageObjectValidationTestHelper.validateMethod(privateElementWaitMethod, expectedPrivateWait);
+
+        //verify beforeLoad method has call to both private wait methods
+        PageObjectMethod beforeLoadMethod = getMethod("generated/load/loadBasicPrivateElement.utam", BEFORE_LOAD_METHOD_NAME);
+        MethodInfo expectedBeforeLoad = new MethodInfo(BEFORE_LOAD_METHOD_NAME, "Object");
+        expectedBeforeLoad.addCodeLine("this.waitForBasicPrivateElement()");
+        expectedBeforeLoad.addCodeLine("return this");
+        PageObjectValidationTestHelper.validateMethod(beforeLoadMethod, expectedBeforeLoad);
+    }
+
+    @Test
+    public void testLoadInPublicBasicElement() {
+        //verify private wait method is created for private element
+        String publicElementWaitMethodName = "waitForBasicPublicElement";
+        PageObjectMethod publicElementWaitMethod = getMethod("generated/load/loadBasicPublicElement.utam", publicElementWaitMethodName);
+        MethodInfo expectedPrivateWait = new MethodInfo(publicElementWaitMethodName, "BasicPublicElementElement");
+        expectedPrivateWait.setNotPublic();
+        expectedPrivateWait.addCodeLine("BasicPublicElementElement statement0 = this.waitFor(() -> {\n"
+                + "BasicPublicElementElement pstatement0 = this.getBasicPublicElement();\n"
+                + "return pstatement0;\n"
+                + "})");
+        expectedPrivateWait.addCodeLine("return statement0");
+        PageObjectValidationTestHelper.validateMethod(publicElementWaitMethod, expectedPrivateWait);
+
+        //verify beforeLoad method has call to both private wait methods
+        PageObjectMethod beforeLoadMethod = getMethod("generated/load/loadBasicPublicElement.utam", BEFORE_LOAD_METHOD_NAME);
+        MethodInfo expectedBeforeLoad = new MethodInfo(BEFORE_LOAD_METHOD_NAME, "Object");
+        expectedBeforeLoad.addCodeLine("this.waitForBasicPublicElement()");
+        expectedBeforeLoad.addCodeLine("return this");
+        PageObjectValidationTestHelper.validateMethod(beforeLoadMethod, expectedBeforeLoad);
+    }
+
+    @Test
+    public void testLoadAndWaitInPublicBasicElement() {
+        //verify private wait method is created for private element
+        String publicElementWaitMethodName = "waitForBasicPublicElement";
+        PageObjectMethod publicElementWaitMethod = getMethod("generated/load/loadAndWaitBasicElement.utam", publicElementWaitMethodName);
+        MethodInfo expectedPrivateWait = new MethodInfo(publicElementWaitMethodName, "BasicPublicElementElement");
+        expectedPrivateWait.addCodeLine("BasicPublicElementElement statement0 = this.waitFor(() -> {\n"
+                + "BasicPublicElementElement pstatement0 = this.getBasicPublicElement();\n"
+                + "return pstatement0;\n"
+                + "})");
+        expectedPrivateWait.addCodeLine("return statement0");
+        PageObjectValidationTestHelper.validateMethod(publicElementWaitMethod, expectedPrivateWait);
+
+        //verify beforeLoad method has call to both private wait methods
+        PageObjectMethod beforeLoadMethod = getMethod("generated/load/loadAndWaitBasicElement.utam", BEFORE_LOAD_METHOD_NAME);
+        MethodInfo expectedBeforeLoad = new MethodInfo(BEFORE_LOAD_METHOD_NAME, "Object");
+        expectedBeforeLoad.addCodeLine("this.waitForBasicPublicElement()");
+        expectedBeforeLoad.addCodeLine("return this");
+        PageObjectValidationTestHelper.validateMethod(beforeLoadMethod, expectedBeforeLoad);
+    }
+
+    @Test
+    public void testLoadInFrame() {
+        String methodName = "waitForFrameElement";
+        PageObjectMethod method = getMethod("generated/load/loadFrameElement.utam", methodName);
+        MethodInfo expected = new MethodInfo(methodName, "FrameElement");
+        expected.setNotPublic();
+        expected.addCodeLine("FrameElement statement0 = this.waitFor(() -> {\n"
+                + "FrameElement pstatement0 = this.getFrameElementElement();\n"
+                + "return pstatement0;\n"
+                + "})");
+        expected.addCodeLine("return statement0");
+        PageObjectValidationTestHelper.validateMethod(method, expected);
+
+        //verify beforeLoad method has call to both private wait methods
+        PageObjectMethod beforeLoadMethod = getMethod("generated/load/loadFrameElement.utam", BEFORE_LOAD_METHOD_NAME);
+        MethodInfo expectedBeforeLoad = new MethodInfo(BEFORE_LOAD_METHOD_NAME, "Object");
+        expectedBeforeLoad.addCodeLine("this.waitForFrameElement()");
+        expectedBeforeLoad.addCodeLine("return this");
+    }
+
+}

--- a/utam-compiler/src/test/resources/generated/compiler.config.json
+++ b/utam-compiler/src/test/resources/generated/compiler.config.json
@@ -53,6 +53,10 @@
     {
       "typeMatch": "generated-wait",
       "pathMatch": ".*/wait"
+    },
+    {
+      "typeMatch": "generated-load",
+      "pathMatch": ".*/load"
     }
   ],
   "copyright" : [

--- a/utam-compiler/src/test/resources/generated/load/loadAndWaitBasicElement.utam.json
+++ b/utam-compiler/src/test/resources/generated/load/loadAndWaitBasicElement.utam.json
@@ -1,0 +1,30 @@
+{
+  "shadow": {
+    "elements": [
+      {
+        "name": "basicPublicElement",
+        "type": [
+          "clickable",
+          "editable"
+        ],
+        "selector": {
+          "css": "basicElement[test]"
+        },
+        "load": true,
+        "wait": true,
+        "public": true
+      }
+    ]
+  },
+  "methods": [
+    {
+      "name": "getText",
+      "compose": [
+        {
+          "element": "root",
+          "apply": "getText"
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/generated/load/loadBasicPrivateElement.utam.json
+++ b/utam-compiler/src/test/resources/generated/load/loadBasicPrivateElement.utam.json
@@ -1,0 +1,28 @@
+{
+  "shadow": {
+    "elements": [
+      {
+        "name": "basicPrivateElement",
+        "type": [
+          "clickable",
+          "editable"
+        ],
+        "selector": {
+          "css": "basicElement[test]"
+        },
+        "load": true
+      }
+    ]
+  },
+  "methods": [
+    {
+      "name": "getText",
+      "compose": [
+        {
+          "element": "root",
+          "apply": "getText"
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/generated/load/loadBasicPublicElement.utam.json
+++ b/utam-compiler/src/test/resources/generated/load/loadBasicPublicElement.utam.json
@@ -1,0 +1,29 @@
+{
+  "shadow": {
+    "elements": [
+      {
+        "name": "basicPublicElement",
+        "type": [
+          "clickable",
+          "editable"
+        ],
+        "selector": {
+          "css": "basicElement[test]"
+        },
+        "load": true,
+        "public": true
+      }
+    ]
+  },
+  "methods": [
+    {
+      "name": "getText",
+      "compose": [
+        {
+          "element": "root",
+          "apply": "getText"
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/generated/load/loadFrameElement.utam.json
+++ b/utam-compiler/src/test/resources/generated/load/loadFrameElement.utam.json
@@ -1,0 +1,14 @@
+{
+  "shadow": {
+    "elements": [
+      {
+        "name": "frameElement",
+        "type": "frame",
+        "selector": {
+          "css": "frame"
+        },
+        "load": true
+      }
+    ]
+  }
+}

--- a/utam-compiler/src/test/resources/validate/basic_element/loadContainer.json
+++ b/utam-compiler/src/test/resources/validate/basic_element/loadContainer.json
@@ -1,0 +1,12 @@
+{
+  "elements": [
+    {
+      "type": "container",
+      "name": "container",
+      "selector": {
+        "css": "container"
+      },
+      "load": true
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/validate/basic_element/loadElementWithArguments.json
+++ b/utam-compiler/src/test/resources/validate/basic_element/loadElementWithArguments.json
@@ -1,0 +1,19 @@
+{
+  "shadow": {
+    "elements": [
+      {
+        "name": "basicElement",
+        "selector": {
+          "css": "basicElement[%s]",
+          "args": [
+            {
+              "name": "selectorArg",
+              "type": "string"
+            }
+          ]
+        },
+        "load": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add boolean property "load" to UTAM Element
- If true
- add private method that waits for element (unless "wait" is set to true, then method waitFor<ElementName> should be public)
- invoke method ^ in beforeLoad

Elements with selector arguments, containers, filters cannot be declared for pre-load.