### PR TITLE
fix(compiler): allow name collision for private wait

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
@@ -177,7 +177,7 @@ public final class UtamElement {
   }
 
   private boolean isPrivateWait() {
-    return isLoad() && !isWait();
+    return (isLoad() && !isWait()) || Boolean.FALSE.equals(isPublic);
   }
   /**
    * Some functionality in compiler can lead to adjusting JSON itself, for example "wait"

--- a/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
+++ b/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
@@ -189,8 +189,12 @@ public class TranslationContext {
     if (methodNames.contains(method.getDeclaration().getName())) {
       throw new UtamCompilationError(VALIDATION.getErrorMessage(504, method.getDeclaration().getName()));
     }
-    // no duplicates - add method
-    methodNames.add(method.getDeclaration().getName());
+
+    // no duplicates - add method if it is public to prevent collisions
+    if (method.isPublic()) {
+      methodNames.add(method.getDeclaration().getName());
+    }
+
     if (method instanceof BasicElementGetterMethod) {
       elementGetters.add((BasicElementGetterMethod) method);
     } else {

--- a/utam-compiler/src/test/java/utam/compiler/helpers/TranslationContextTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/helpers/TranslationContextTests.java
@@ -96,6 +96,7 @@ public class TranslationContextTests {
     MethodDeclaration declaration = mock(MethodDeclaration.class);
     when(declaration.getName()).thenReturn("name");
     when(method.getDeclaration()).thenReturn(declaration);
+    when(method.isPublic()).thenReturn(true);
     TranslationContext context = getTestTranslationContext();
     context.setMethod(method);
     assertThat(context.getMethods(), hasSize(1));

--- a/utam-compiler/src/test/resources/validate/wait/waitForNameCollisionPrivate.json
+++ b/utam-compiler/src/test/resources/validate/wait/waitForNameCollisionPrivate.json
@@ -1,0 +1,22 @@
+{
+  "elements": [
+    {
+      "name": "test",
+      "selector": {
+        "css": "test"
+      },
+      "wait": true,
+      "public": false
+    }
+  ],
+  "methods": [
+    {
+      "name": "waitForTest",
+      "compose": [
+        {
+          "element": "test"
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/validate/wait/waitForNameCollisionPublic.json
+++ b/utam-compiler/src/test/resources/validate/wait/waitForNameCollisionPublic.json
@@ -1,0 +1,22 @@
+{
+  "elements": [
+    {
+      "name": "test",
+      "selector": {
+        "css": "test"
+      },
+      "wait": true,
+      "public": true
+    }
+  ],
+  "methods": [
+    {
+      "name": "waitForTest",
+      "compose": [
+        {
+          "element": "test"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The `wait` feature can generate names that collide with user-provided names.

(current, working as expected) An element named `test` with `wait:true` and `public:true` _**will**_ generate a public getter named `waitForTest`. This throws a compile error.

(changed, was broken) An element named `test` with `wait:true` and `public:false` **_will not_** generate a public getter named `waitForTest`. This should not throw an error if a user defines a method named `waitForTest`.

Code review notes: This is branched off the formatting PR.

QA notes: Look the JSON PO files in the PR to verify they compile as expected.
