### PR TITLE
fix(compiler): name collisions on waits

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamComposeMethod.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamComposeMethod.java
@@ -58,6 +58,7 @@ class UtamComposeMethod extends UtamMethod {
    * @param name name of the method
    * @param description description of the method
    * @param compose statements
+   * @param isPublic if the method is public
    */
   UtamComposeMethod(
       String name,

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
@@ -210,8 +210,8 @@ public final class UtamElement {
     List<UtamMethodAction> compose =
         Collections.singletonList(new UtamMethodActionWaitForElement(name, isLoad()));
 
-    // q: why does this determine the public nature?
-    Boolean isPublic = !isLoad() || isWait();
+    // Wait methods are public
+    Boolean isPublic = isWait();
 
     return new UtamComposeMethod(methodName, description, compose, isPublic);
   }

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
@@ -176,7 +176,7 @@ public final class UtamElement {
   }
 
   private boolean isPrivateWait() {
-    return isLoad() && !isWait();
+    return (isLoad() && !isWait()) || Boolean.FALSE.equals(isPublic);
   }
 
   /**

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
@@ -175,10 +175,6 @@ public final class UtamElement {
     return isLoad() || isWait();
   }
 
-  private boolean isPrivateWait() {
-    return (isLoad() && !isWait()) || Boolean.FALSE.equals(isPublic);
-  }
-
   /**
    * Some functionality in compiler can lead to adjusting JSON itself, for example "wait"
    *
@@ -213,7 +209,11 @@ public final class UtamElement {
             null);
     List<UtamMethodAction> compose =
         Collections.singletonList(new UtamMethodActionWaitForElement(name, isLoad()));
-    return new UtamComposeMethod(methodName, description, compose, !isPrivateWait());
+
+    // q: why does this determine the public nature?
+    Boolean isPublic = !isLoad() || isWait();
+
+    return new UtamComposeMethod(methodName, description, compose, isPublic);
   }
 
   /**

--- a/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
+++ b/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
@@ -143,8 +143,8 @@ public class TranslationContext {
     TypeProvider type = translationTypesConfig.getInterfaceType(typeStr);
     if (customTypesMap.containsKey(type.getSimpleName())) {
       TypeProvider alreadyDeclared = customTypesMap.get(type.getSimpleName());
-      // if simple name is same, but full is not - resolve collision by using full
-      // name instead of short name
+      // if simple name is same, but full is not - resolve collision by using full name instead
+      // short name
       // this allows to avoid importing class with simple names twice
       if (!alreadyDeclared.getFullName().equals(type.getFullName())) {
         type = new PageObjectWithNamesCollisionType(type);
@@ -192,10 +192,8 @@ public class TranslationContext {
       throw new UtamCompilationError(
           VALIDATION.getErrorMessage(504, method.getDeclaration().getName()));
     }
-
     // no duplicates - add method
     methodNames.add(method.getDeclaration().getName());
-
     if (method instanceof BasicElementGetterMethod) {
       elementGetters.add((BasicElementGetterMethod) method);
     } else {

--- a/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
+++ b/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
@@ -143,8 +143,8 @@ public class TranslationContext {
     TypeProvider type = translationTypesConfig.getInterfaceType(typeStr);
     if (customTypesMap.containsKey(type.getSimpleName())) {
       TypeProvider alreadyDeclared = customTypesMap.get(type.getSimpleName());
-      // if simple name is same, but full is not - resolve collision by using full name instead
-      // short name
+      // if simple name is same, but full is not - resolve collision by using full
+      // name instead of short name
       // this allows to avoid importing class with simple names twice
       if (!alreadyDeclared.getFullName().equals(type.getFullName())) {
         type = new PageObjectWithNamesCollisionType(type);
@@ -188,15 +188,13 @@ public class TranslationContext {
    */
   public void setMethod(PageObjectMethod method) {
     // first check if same method already exists
-    if (method.isPublic() && methodNames.contains(method.getDeclaration().getName())) {
+    if (methodNames.contains(method.getDeclaration().getName())) {
       throw new UtamCompilationError(
           VALIDATION.getErrorMessage(504, method.getDeclaration().getName()));
     }
 
-    // no duplicates - add method if it is public to prevent collisions
-    if (method.isPublic()) {
-      methodNames.add(method.getDeclaration().getName());
-    }
+    // no duplicates - add method
+    methodNames.add(method.getDeclaration().getName());
 
     if (method instanceof BasicElementGetterMethod) {
       elementGetters.add((BasicElementGetterMethod) method);

--- a/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
+++ b/utam-compiler/src/main/java/utam/compiler/helpers/TranslationContext.java
@@ -188,12 +188,16 @@ public class TranslationContext {
    */
   public void setMethod(PageObjectMethod method) {
     // first check if same method already exists
-    if (methodNames.contains(method.getDeclaration().getName())) {
+    if (method.isPublic() && methodNames.contains(method.getDeclaration().getName())) {
       throw new UtamCompilationError(
           VALIDATION.getErrorMessage(504, method.getDeclaration().getName()));
     }
-    // no duplicates - add method
-    methodNames.add(method.getDeclaration().getName());
+
+    // no duplicates - add method if it is public to prevent collisions
+    if (method.isPublic()) {
+      methodNames.add(method.getDeclaration().getName());
+    }
+
     if (method instanceof BasicElementGetterMethod) {
       elementGetters.add((BasicElementGetterMethod) method);
     } else {

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamElementLoadTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamElementLoadTests.java
@@ -153,6 +153,7 @@ public class UtamElementLoadTests {
     MethodInfo expectedBeforeLoad = new MethodInfo(BEFORE_LOAD_METHOD_NAME, "Object");
     expectedBeforeLoad.addCodeLine("this.waitForFrameElement()");
     expectedBeforeLoad.addCodeLine("return this");
+    PageObjectValidationTestHelper.validateMethod(beforeLoadMethod, expectedBeforeLoad);
   }
 
   @Test
@@ -175,6 +176,7 @@ public class UtamElementLoadTests {
     MethodInfo expectedBeforeLoad = new MethodInfo(BEFORE_LOAD_METHOD_NAME, "Object");
     expectedBeforeLoad.addCodeLine("this.waitForBasicElement()");
     expectedBeforeLoad.addCodeLine("return this");
+    PageObjectValidationTestHelper.validateMethod(beforeLoadMethod, expectedBeforeLoad);
   }
 
   @Test

--- a/utam-compiler/src/test/java/utam/compiler/helpers/TranslationContextTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/helpers/TranslationContextTests.java
@@ -99,6 +99,7 @@ public class TranslationContextTests {
     MethodDeclaration declaration = mock(MethodDeclaration.class);
     when(declaration.getName()).thenReturn("name");
     when(method.getDeclaration()).thenReturn(declaration);
+    when(method.isPublic()).thenReturn(true);
     TranslationContext context = getTestTranslationContext();
     context.setMethod(method);
     assertThat(context.getMethods(), hasSize(1));

--- a/utam-compiler/src/test/java/utam/compiler/translator/DefaultTranslatorRunnerTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/translator/DefaultTranslatorRunnerTests.java
@@ -41,14 +41,12 @@ import org.testng.annotations.Test;
 import utam.compiler.UtamCompilationError;
 import utam.compiler.grammar.DeserializerUtilities;
 import utam.compiler.grammar.TestUtilities;
-import utam.compiler.helpers.TranslationContext;
 import utam.compiler.helpers.TypeUtilities.FromString;
 import utam.compiler.translator.DefaultSourceConfigurationTests.TranslatorConfigWithProfile;
 import utam.core.declarative.lint.LintingConfig;
 import utam.core.declarative.representation.PageObjectClass;
 import utam.core.declarative.representation.PageObjectDeclaration;
 import utam.core.declarative.representation.PageObjectInterface;
-import utam.core.declarative.representation.PageObjectMethod;
 import utam.core.declarative.translator.ProfileConfiguration;
 import utam.core.declarative.translator.TranslatorConfig;
 import utam.core.declarative.translator.TranslatorRunner;
@@ -438,16 +436,16 @@ public class DefaultTranslatorRunnerTests {
   }
 
   @Test
-  public void testWaitForNameCollisionPrivatePasses() {
-    TranslationContext context =
-        new DeserializerUtilities().getContext("validate/wait/waitForNameCollisionPrivate");
-
-    PageObjectMethod publicWaitForTest = context.getMethods().get(1);
-    PageObjectMethod privateWaitForTest = context.getMethods().get(2);
-
+  public void testWaitForNameCollisionPrivateThrows() {
+    UtamCompilationError e =
+        expectThrows(
+            UtamCompilationError.class,
+            () ->
+                new DeserializerUtilities()
+                    .getContext("validate/wait/waitForNameCollisionPrivate"));
     assertThat(
-        publicWaitForTest.getDeclaration().getName(),
-        equalTo(privateWaitForTest.getDeclaration().getName()));
-    assertThat(publicWaitForTest.isPublic(), equalTo(!privateWaitForTest.isPublic()));
+        e.getMessage(),
+        containsString(
+            "error 504: method \"waitForTest\": method with the same name was already declared"));
   }
 }

--- a/utam-compiler/src/test/java/utam/compiler/translator/DefaultTranslatorRunnerTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/translator/DefaultTranslatorRunnerTests.java
@@ -38,14 +38,17 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hamcrest.Matchers;
 import org.testng.annotations.Test;
+import utam.compiler.UtamCompilationError;
 import utam.compiler.grammar.DeserializerUtilities;
 import utam.compiler.grammar.TestUtilities;
+import utam.compiler.helpers.TranslationContext;
 import utam.compiler.helpers.TypeUtilities.FromString;
 import utam.compiler.translator.DefaultSourceConfigurationTests.TranslatorConfigWithProfile;
 import utam.core.declarative.lint.LintingConfig;
 import utam.core.declarative.representation.PageObjectClass;
 import utam.core.declarative.representation.PageObjectDeclaration;
 import utam.core.declarative.representation.PageObjectInterface;
+import utam.core.declarative.representation.PageObjectMethod;
 import utam.core.declarative.translator.ProfileConfiguration;
 import utam.core.declarative.translator.TranslatorConfig;
 import utam.core.declarative.translator.TranslatorRunner;
@@ -419,5 +422,32 @@ public class DefaultTranslatorRunnerTests {
         e.getMessage(),
         containsString(
             "@ElementMarker.Find(css = \"css\")\n" + "private ElementLocation test-error;"));
+  }
+
+  @Test
+  public void testWaitForNameCollisionPublicThrows() {
+    UtamCompilationError e =
+        expectThrows(
+            UtamCompilationError.class,
+            () ->
+                new DeserializerUtilities().getContext("validate/wait/waitForNameCollisionPublic"));
+    assertThat(
+        e.getMessage(),
+        containsString(
+            "error 504: method \"waitForTest\": method with the same name was already declared"));
+  }
+
+  @Test
+  public void testWaitForNameCollisionPrivatePasses() {
+    TranslationContext context =
+        new DeserializerUtilities().getContext("validate/wait/waitForNameCollisionPrivate");
+
+    PageObjectMethod publicWaitForTest = context.getMethods().get(1);
+    PageObjectMethod privateWaitForTest = context.getMethods().get(2);
+
+    assertThat(
+        publicWaitForTest.getDeclaration().getName(),
+        equalTo(privateWaitForTest.getDeclaration().getName()));
+    assertThat(publicWaitForTest.isPublic(), equalTo(!privateWaitForTest.isPublic()));
   }
 }

--- a/utam-compiler/src/test/resources/validate/wait/waitForNameCollisionPrivate.json
+++ b/utam-compiler/src/test/resources/validate/wait/waitForNameCollisionPrivate.json
@@ -1,0 +1,22 @@
+{
+  "elements": [
+    {
+      "name": "test",
+      "selector": {
+        "css": "test"
+      },
+      "wait": true,
+      "public": false
+    }
+  ],
+  "methods": [
+    {
+      "name": "waitForTest",
+      "compose": [
+        {
+          "element": "test"
+        }
+      ]
+    }
+  ]
+}

--- a/utam-compiler/src/test/resources/validate/wait/waitForNameCollisionPublic.json
+++ b/utam-compiler/src/test/resources/validate/wait/waitForNameCollisionPublic.json
@@ -1,0 +1,22 @@
+{
+  "elements": [
+    {
+      "name": "test",
+      "selector": {
+        "css": "test"
+      },
+      "wait": true,
+      "public": true
+    }
+  ],
+  "methods": [
+    {
+      "name": "waitForTest",
+      "compose": [
+        {
+          "element": "test"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The `wait` feature can generate names that collide with user-provided names.

(current, working as expected) An element named `test` with `wait:true` and `public:true` _**will**_ generate a public getter named `waitForTest`. This throws a compile error.

(changed, was broken) An element named `test` with `wait:true` and `public:false` **_will not_** generate a public getter named `waitForTest`. This should not throw an error if a user defines a method named `waitForTest`.

Code review notes: This is branched off the formatting PR.

QA notes: Look the JSON PO files in the PR to verify they compile as expected.
