### PR TITLE
fix(compiler): change waitFor 504 error to 505

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/grammar/JsonDeserializer.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/JsonDeserializer.java
@@ -118,8 +118,14 @@ public final class JsonDeserializer
   public UtamPageObject deserialize(JsonParser parser, DeserializationContext ctxt) {
     try {
       ObjectMapper mapper = getObjectMapperWithSettings();
+
+      // Maps the incoming JSON to a class, directly without processing
       UtamPageObject utamPageObject = mapper.readValue(parser, UtamPageObject.class);
+
+      // Touch up the JSON, adjusting things like names for `waitFor`, etc.
       utamPageObject.preProcess();
+
+      // Compile the page object now that is has been corrected
       utamPageObject.compile(this.context);
       return utamPageObject;
     } catch (Exception e) {

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
@@ -179,28 +179,36 @@ public final class UtamElement {
    * Some functionality in compiler can lead to adjusting JSON itself, for example "wait"
    *
    * @param pageObject de-serialized page object
+   * @param methods The list of methods parsed from the JSON, used to detect name collisions
    */
-  void preProcessElement(UtamPageObject pageObject) {
+  void preProcessElement(UtamPageObject pageObject, List<UtamMethod> methods) {
     if (isWaitOrLoad()) {
-      UtamComposeMethod composeMethod = buildWaitForComposeMethod();
+      UtamComposeMethod composeMethod = buildWaitForComposeMethod(methods);
       pageObject.setComposeMethod(composeMethod);
       if (isLoad()) {
         pageObject.getBeforeLoad().add(buildApplyForLoad(composeMethod.name));
       }
     }
     if (shadow != null) {
-      shadow.elements.forEach(utamElement -> utamElement.preProcessElement(pageObject));
+      shadow.elements.forEach(utamElement -> utamElement.preProcessElement(pageObject, methods));
     }
-    elements.forEach(utamElement -> utamElement.preProcessElement(pageObject));
+    elements.forEach(utamElement -> utamElement.preProcessElement(pageObject, methods));
   }
 
   /**
    * Build compose method to wait for the element
    *
+   * @param methods The list of methods parsed from the JSON, used to detect name collisions
    * @return UtamComposeMethod object
    */
-  private UtamComposeMethod buildWaitForComposeMethod() {
+  private UtamComposeMethod buildWaitForComposeMethod(List<UtamMethod> methods) {
     String methodName = "waitFor" + name.substring(0, 1).toUpperCase() + name.substring(1);
+
+    // Check if the newly generated name will cause a name collision and throw an error
+    if (methods.stream().anyMatch(m -> m.name.equals(methodName))) {
+      throw new UtamCompilationError(VALIDATION.getErrorMessage(505, methodName, name));
+    }
+
     UtamMethodDescription description =
         new UtamMethodDescription(
             Collections.singletonList(String.format("method that waits for element \"%s\"", name)),

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamPageObject.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamPageObject.java
@@ -172,9 +172,9 @@ public final class UtamPageObject {
    */
   void preProcess() {
     if (shadow != null) {
-      shadow.elements.forEach(utamElement -> utamElement.preProcessElement(this));
+      shadow.elements.forEach(utamElement -> utamElement.preProcessElement(this, methods));
     }
-    elements.forEach(utamElement -> utamElement.preProcessElement(this));
+    elements.forEach(utamElement -> utamElement.preProcessElement(this, methods));
   }
 
   /**

--- a/utam-compiler/src/main/resources/errors.config.json
+++ b/utam-compiler/src/main/resources/errors.config.json
@@ -185,6 +185,10 @@
     "message": "method \"%s\": method with the same name was already declared"
   },
   {
+    "code": 505,
+    "message": "method \"%s\": the given method name would duplicate the name of a generated helper function for element \"%s\""
+  },
+  {
     "code": 600,
     "message": "method \"%s\" statement: incorrect compose statement format",
     "docs": "https://utam.dev/grammar/spec#compose-method"

--- a/utam-compiler/src/test/java/utam/compiler/translator/DefaultTranslatorRunnerTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/translator/DefaultTranslatorRunnerTests.java
@@ -432,7 +432,8 @@ public class DefaultTranslatorRunnerTests {
     assertThat(
         e.getMessage(),
         containsString(
-            "error 504: method \"waitForTest\": method with the same name was already declared"));
+            "error 505: method \"waitForTest\": the given method name would duplicate the name of a"
+                + " generated helper function for element \"test\""));
   }
 
   @Test
@@ -446,6 +447,7 @@ public class DefaultTranslatorRunnerTests {
     assertThat(
         e.getMessage(),
         containsString(
-            "error 504: method \"waitForTest\": method with the same name was already declared"));
+            "error 505: method \"waitForTest\": the given method name would duplicate the name of a"
+                + " generated helper function for element \"test\""));
   }
 }


### PR DESCRIPTION
Updates the compiler's error message to align with the JS compiler by providing a better error when the generated `waitFor` name has a collision with a user-defined method name.

Continues the work done in #207 .

The fix pushes a list of methods along so when we generate the `waitFor` function name, we can check if it would be unique.