### PR TITLE
feat: disable linting violation for  multiple boundaries

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
@@ -55,17 +55,7 @@ public class LintingConfigJson implements LintingConfig {
    */
   public static final LintingConfig DEFAULT_LINTING_CONFIG =
       new LintingConfigJson(
-          false,
-          false,
-          DEFAULT_SARIF_OUTPUT_FILE,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null);
+          false, false, DEFAULT_SARIF_OUTPUT_FILE, null, null, null, null, null, null, null, null);
 
   private final List<LintingRuleImpl> localRules = new ArrayList<>();
   private final List<LintingRuleImpl> globalRules = new ArrayList<>();

--- a/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/LintingConfigJson.java
@@ -29,7 +29,6 @@ import utam.compiler.lint.LintingRuleImpl.RequiredMetadata;
 import utam.compiler.lint.LintingRuleImpl.RequiredMethodDescription;
 import utam.compiler.lint.LintingRuleImpl.RequiredRootDescription;
 import utam.compiler.lint.LintingRuleImpl.RootSelectorExistsForElement;
-import utam.compiler.lint.LintingRuleImpl.SingleShadowBoundaryAllowed;
 import utam.compiler.lint.LintingRuleImpl.UniqueRootSelector;
 import utam.compiler.lint.LintingRuleImpl.UniqueSelectorInsidePageObject;
 import utam.core.declarative.lint.LintingConfig;
@@ -66,7 +65,6 @@ public class LintingConfigJson implements LintingConfig {
           null,
           null,
           null,
-          null,
           null);
 
   private final List<LintingRuleImpl> localRules = new ArrayList<>();
@@ -85,8 +83,6 @@ public class LintingConfigJson implements LintingConfig {
       @JsonProperty(value = "requiredRootDescription") LintRuleOverride requiredRootDescription,
       @JsonProperty(value = "requiredAuthor") LintRuleOverride requiredAuthor,
       @JsonProperty(value = "requiredMethodDescription") LintRuleOverride requiredMethodDescription,
-      @JsonProperty(value = "requiredSingleShadowRoot")
-          LintRuleOverride singleShadowBoundaryAllowed,
       @JsonProperty(value = "duplicateRootSelectors") LintRuleOverride uniqueRootSelectors,
       @JsonProperty(value = "elementCantHaveRootSelector") LintRuleOverride rootSelectorExists,
       @JsonProperty(value = "duplicateCustomSelectors") LintRuleOverride customWrongType,
@@ -98,7 +94,6 @@ public class LintingConfigJson implements LintingConfig {
     localRules.add(new RequiredRootDescription(requiredRootDescription));
     localRules.add(new RequiredAuthor(requiredAuthor));
     localRules.add(new RequiredMethodDescription(requiredMethodDescription));
-    localRules.add(new SingleShadowBoundaryAllowed(singleShadowBoundaryAllowed));
     localRules.add(new RequiredMetadata(requiredMetadata));
     globalRules.add(new UniqueRootSelector(uniqueRootSelectors));
     globalRules.add(new RootSelectorExistsForElement(rootSelectorExists));

--- a/utam-compiler/src/main/java/utam/compiler/lint/LintingRuleImpl.java
+++ b/utam-compiler/src/main/java/utam/compiler/lint/LintingRuleImpl.java
@@ -334,34 +334,6 @@ abstract class LintingRuleImpl implements LintingRule {
   }
 
   /**
-   * Check for single shadow boundary at the root level
-   *
-   * @author elizaveta.ivanova
-   * @since 242
-   */
-  static class SingleShadowBoundaryAllowed extends LintingRuleImpl {
-    SingleShadowBoundaryAllowed(LintRuleOverride override) {
-      super("ULR05", override);
-    }
-
-    @Override
-    public void validate(List<LintingError> errors, PageObjectLinting pageObject) {
-      if (isEnabled(pageObject)) {
-        for (String elementName : pageObject.getShadowBoundaries()) {
-          FileSearchContext context =
-              new FileSearchContextImpl(new String[] {"elements", elementName});
-          errors.add(
-              getError(
-                  pageObject,
-                  pageObject.findCodeLine(context, "shadow"),
-                  String.format(this.help, elementName),
-                  elementName));
-        }
-      }
-    }
-  }
-
-  /**
    * Root selector should be unique across all POs
    *
    * @author elizaveta.ivanova

--- a/utam-compiler/src/main/resources/errors.config.json
+++ b/utam-compiler/src/main/resources/errors.config.json
@@ -374,10 +374,6 @@
     "message": "method \"%s\" does not have description"
   },
   {
-    "code": 2004,
-    "message": "only root shadow boundary is allowed, please create another page object for the element \"%s\""
-  },
-  {
     "code": 2005,
     "message": "property \"author\" is missing in the root description"
   },

--- a/utam-compiler/src/main/resources/rules.config.json
+++ b/utam-compiler/src/main/resources/rules.config.json
@@ -32,14 +32,6 @@
         "violation": "warning"
     },
     {
-        "ruleId": "ULR05",
-        "errorCode": 2004,
-        "name": "Single shadowRoot",
-        "description": "Check only one shadowRoot present at the component root",
-        "help": "remove \"shadow\" under element \"%s\" and create separate page object for its content",
-        "violation": "warning"
-    },
-    {
         "ruleId": "ULR06",
         "errorCode": 3001,
         "name": "Unique root selector",

--- a/utam-compiler/src/test/java/utam/compiler/lint/LintingRuleTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/lint/LintingRuleTests.java
@@ -73,7 +73,7 @@ public class LintingRuleTests {
   @Test
   public void testDuplicateSelectorsInsideOneFile() {
     List<LintingError> errors = test("lint/rules/defaultConfig");
-    assertThat(errors, hasSize(5));
+    assertThat(errors, hasSize(4));
     LintingError error = errors.get(0);
     assertThat(
         error.getFullMessage(),
@@ -135,7 +135,7 @@ public class LintingRuleTests {
   @Test
   public void testRequiredDescription() {
     List<LintingError> errors = test("lint/rules/defaultConfig");
-    assertThat(errors, hasSize(5));
+    assertThat(errors, hasSize(4));
     LintingError error = errors.get(2);
     assertThat(
         error.getFullMessage(),
@@ -158,21 +158,6 @@ public class LintingRuleTests {
         error.getFixSuggestion(),
         equalTo("add \"description\" property to the method \"nodescription\""));
     assertThat(error.getSourceLine(), equalTo(47));
-    error = errors.get(4);
-    assertThat(
-        error.getFullMessage(),
-        equalTo(
-            "lint rule ULR05 failure in page object test/lint/rules/defaultConfig: warning 2004:"
-                + " only root shadow boundary is allowed, please create another page object for the"
-                + " element \"three\"; remove \"shadow\" under element \"three\" and create"
-                + " separate page object for its content"));
-    assertThat(error.getRuleId(), equalTo("ULR05"));
-    assertThat(
-        error.getFixSuggestion(),
-        equalTo(
-            "remove \"shadow\" under element \"three\" and create separate page object for its"
-                + " content"));
-    assertThat(error.getSourceLine(), equalTo(25));
   }
 
   @Test
@@ -194,27 +179,6 @@ public class LintingRuleTests {
                 + "add \"author\" property to the root description"));
     assertThat(error.getRuleId(), equalTo("ULR03"));
     assertThat(error.getSourceLine(), equalTo(2));
-  }
-
-  @Test
-  public void testShadowBoundaryRule() {
-    List<LintingError> errors = test("lint/rules/defaultConfig");
-    assertThat(errors, hasSize(5));
-    LintingError error = errors.get(4);
-    assertThat(
-        error.getFullMessage(),
-        equalTo(
-            "lint rule ULR05 failure in page object test/lint/rules/defaultConfig: warning 2004:"
-                + " only root shadow boundary is allowed, please create another page object for the"
-                + " element \"three\"; remove \"shadow\" under element \"three\" and create"
-                + " separate page object for its content"));
-    assertThat(error.getRuleId(), equalTo("ULR05"));
-    assertThat(
-        error.getFixSuggestion(),
-        equalTo(
-            "remove \"shadow\" under element \"three\" and create separate page object for its"
-                + " content"));
-    assertThat(error.getSourceLine(), equalTo(25));
   }
 
   @Test

--- a/utam-compiler/src/test/java/utam/compiler/lint/SarifConverterTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/lint/SarifConverterTests.java
@@ -91,7 +91,7 @@ public class SarifConverterTests {
     assertThat(toolComponent.getName(), equalTo(SARIF_NAME));
     assertThat(toolComponent.getInformationUri(), equalTo(SARIF_INFORMATION_URI));
     assertThat(toolComponent.getSemanticVersion(), equalTo(SARIF_SEMANTIC_VERSION.value()));
-    assertThat(toolComponent.getRules(), hasSize(9));
+    assertThat(toolComponent.getRules(), hasSize(8));
 
     // rule properties
     String ruleId = "ULR03";

--- a/utam-compiler/src/test/resources/lint/metadata/presence.config.json
+++ b/utam-compiler/src/test/resources/lint/metadata/presence.config.json
@@ -16,9 +16,6 @@
     "requiredMethodDescription": {
       "violation": "disabled"
     },
-    "requiredSingleShadowRoot": {
-      "violation": "disabled"
-    },
     "duplicateRootSelectors": {
       "violation" : "disabled"
     },

--- a/utam-compiler/src/test/resources/lint/metadata/structure.config.json
+++ b/utam-compiler/src/test/resources/lint/metadata/structure.config.json
@@ -16,9 +16,6 @@
     "requiredMethodDescription": {
       "violation": "disabled"
     },
-    "requiredSingleShadowRoot": {
-      "violation": "disabled"
-    },
     "duplicateRootSelectors": {
       "violation" : "disabled"
     },


### PR DESCRIPTION
After implementing ability for custom and container to have nested elements, we no longer consider multiple shadow boundaries a violation.
Documentation https://github.com/salesforce-experience-platform-emu/utam-docs/pull/985