### PR TITLE
feat: support for nullable flag in container element

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamElement.java
@@ -44,6 +44,7 @@ import utam.compiler.lint.PageObjectLintingImpl.ElementScope;
 import utam.compiler.lint.PageObjectLintingImpl.ElementSelector;
 import utam.compiler.lint.PageObjectLintingImpl.Method;
 import utam.compiler.representation.ContainerMethod;
+import utam.compiler.representation.ContainerMethod.ElementOptions;
 import utam.compiler.representation.CustomElementMethod;
 import utam.compiler.representation.ElementField;
 import utam.compiler.representation.ElementMethod;
@@ -606,8 +607,6 @@ public class UtamElement {
       }
       VALIDATION.validateUnsupportedProperty(
           filter, validationContext, "filter", CONTAINER_SUPPORTED_PROPERTIES);
-      VALIDATION.validateUnsupportedProperty(
-          isNullable, validationContext, "nullable", CONTAINER_SUPPORTED_PROPERTIES);
     }
 
     @Override
@@ -615,15 +614,15 @@ public class UtamElement {
         TranslationContext context, ElementContext scopeElement, boolean isExpandScopeShadowRoot) {
       LocatorCodeGeneration locator = selector.getElementCodeGenerationHelper(name, context);
       ElementContext elementContext = new ElementContext.Container(scopeElement, name);
+      ElementOptions options = new ElementOptions(isPublic, isNullable, isExpandScopeShadowRoot);
       PageObjectMethod method;
       if (selector.isReturnAll()) {
         method =
             new ContainerMethod.WithSelectorReturnsList(
-                scopeElement, isExpandScopeShadowRoot, name, locator, isPublic(), description);
+                scopeElement, name, locator, description, options);
       } else {
         method =
-            new ContainerMethod.WithSelector(
-                scopeElement, isExpandScopeShadowRoot, name, locator, isPublic(), description);
+            new ContainerMethod.WithSelector(scopeElement, name, locator, description, options);
       }
       elementContext.setElementMethod(method, context);
       context.setElement(elementContext, null);

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamElementCustomTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamElementCustomTests.java
@@ -178,7 +178,7 @@ public class UtamElementCustomTests {
     expectedGetter.addCodeLine(
         "LocatorBy nestedContainerLocator = LocatorBy.byCss(\":scope > *:first-child\")");
     expectedGetter.addCodeLine(
-        "return this.container(customRootScope, true).load(pageObjectType,"
+        "return this.container(customRootScope).expandShadowRoot(true).build().load(pageObjectType,"
             + " nestedContainerLocator)");
     expectedGetter.addImportedTypes(PAGE_OBJECT.getFullName());
     expectedGetter.addImpliedImportedTypes(

--- a/utam-compiler/src/test/resources/container/containerNullable.json
+++ b/utam-compiler/src/test/resources/container/containerNullable.json
@@ -1,0 +1,24 @@
+{
+  "elements" : [
+    {
+      "name": "publicNullableList",
+      "type": "container",
+      "public": true,
+      "nullable": true,
+      "selector": {
+        "css": ".container",
+        "returnAll": true
+      }
+    }
+  ],
+  "shadow": {
+    "elements": [
+      {
+        "name": "publicNullable",
+        "type": "container",
+        "public": true,
+        "nullable": true
+      }
+    ]
+  }
+}

--- a/utam-compiler/src/test/resources/generated/container/containerNullable.utam.json
+++ b/utam-compiler/src/test/resources/generated/container/containerNullable.utam.json
@@ -1,0 +1,35 @@
+{
+  "elements": [
+    {
+      "name": "publicNullable",
+      "type": "container",
+      "public": true,
+      "nullable": true
+    },
+    {
+      "name": "publicNullableList",
+      "type": "container",
+      "public": true,
+      "nullable": true,
+      "selector": {
+        "css": ".container",
+        "returnAll": true
+      }
+    },
+    {
+      "name": "privateNullable",
+      "type": "container",
+      "nullable": true
+    }
+  ],
+  "methods" : [
+    {
+      "name" : "getPrivateNullableContainer",
+      "compose" : [
+        {
+          "element" : "privateNullable"
+        }
+      ]
+    }
+  ]
+}

--- a/utam-core/src/main/java/utam/core/framework/base/BasePageObject.java
+++ b/utam-core/src/main/java/utam/core/framework/base/BasePageObject.java
@@ -148,15 +148,13 @@ public abstract class BasePageObject extends UtamBaseImpl implements PageObject 
   }
 
   /**
-   * scopes custom element in certain location
+   * scopes container element in certain location
    *
    * @param scopeElement scope element (can be root)
-   * @param isExpandShadowRoot expand flag
-   * @return builder
+   * @return builder for container element
    */
-  protected final ContainerElement container(
-      BasicElement scopeElement, boolean isExpandShadowRoot) {
-    return new ContainerElementImpl(getFactory(), scopeElement, isExpandShadowRoot);
+  protected final ContainerElement container(BasicElement scopeElement) {
+    return new ContainerElementImpl(getFactory(), scopeElement);
   }
 
   /**

--- a/utam-core/src/main/java/utam/core/framework/base/ContainerElementPageObject.java
+++ b/utam-core/src/main/java/utam/core/framework/base/ContainerElementPageObject.java
@@ -28,10 +28,14 @@ public final class ContainerElementPageObject extends ContainerElementImpl
   /**
    * Initializes a new instance of the ContainerElementPageObject class
    *
-   * @param container the ContainerElement used for scope in integration with external Page Objects
+   * @param containerElement the ContainerElement used for scope in integration with external Page
+   *     Objects
    */
-  ContainerElementPageObject(ContainerElementImpl container) {
-    super(container);
+  ContainerElementPageObject(ContainerElementImpl containerElement) {
+    super(containerElement.factory, containerElement.containerScope);
+    this.nullable(containerElement.findContext.isNullable());
+    this.expandShadowRoot(containerElement.findContext.isExpandScopeShadowRoot());
+    this.build();
   }
 
   /**

--- a/utam-core/src/main/java/utam/core/framework/consumer/ContainerElement.java
+++ b/utam-core/src/main/java/utam/core/framework/consumer/ContainerElement.java
@@ -23,21 +23,44 @@ public interface ContainerElement {
    * Load UTAM Page object using current element as scope
    *
    * @param utamPageObjectType type to load
-   * @param injectRootLocator inject root into created page object instance
+   * @param injectedRoot injected root locator into created page object instance
    * @param <T> UTAM page object type
    * @return UTAM page object instance
    */
-  <T extends PageObject> T load(Class<T> utamPageObjectType, Locator injectRootLocator);
+  <T extends PageObject> T load(Class<T> utamPageObjectType, Locator injectedRoot);
 
   /**
    * Load list of UTAM Page object using current element as a scope
    *
    * @param utamPageObjectType type to load
-   * @param injectRootLocator inject root into created page object instance
+   * @param injectedRoot injected root locator into created page object instance
    * @param <T> UTAM page object type
    * @return UTAM page object instance
    */
-  <T extends PageObject> List<T> loadList(Class<T> utamPageObjectType, Locator injectRootLocator);
+  <T extends PageObject> List<T> loadList(Class<T> utamPageObjectType, Locator injectedRoot);
+
+  /**
+   * Set parameter to expand shadow root
+   *
+   * @param isExpand value
+   * @return instance of self
+   */
+  ContainerElement expandShadowRoot(boolean isExpand);
+
+  /**
+   * Set nullable parameter
+   *
+   * @param isNullable value
+   * @return instance of self
+   */
+  ContainerElement nullable(boolean isNullable);
+
+  /**
+   * Build search context after all parameters were set
+   *
+   * @return instance of self
+   */
+  ContainerElement build();
 
   /**
    * Inject container element as a root into external non-UTAM page object that should be scoped

--- a/utam-core/src/test/java/utam/core/framework/base/ContainerElementPageObjectTests.java
+++ b/utam-core/src/test/java/utam/core/framework/base/ContainerElementPageObjectTests.java
@@ -35,7 +35,8 @@ public class ContainerElementPageObjectTests {
   private static ContainerElementPageObject getMockPageObject() {
     MockUtilities mock = new MockUtilities();
     ContainerElementImpl containerElement =
-        new ContainerElementImpl(mock.getFactory(), mock.getElementAdapter(), false);
+        new ContainerElementImpl(mock.getFactory(), mock.getElementAdapter());
+    containerElement.build();
     return new ContainerElementPageObject(containerElement);
   }
 
@@ -157,7 +158,9 @@ public class ContainerElementPageObjectTests {
 
     final <T extends PageObject> T getContainerContent(
         Class<T> pageObjectType, boolean isExpandShadowRoot) {
-      return this.container(this.getRootElement(), isExpandShadowRoot)
+      return this.container(this.getRootElement())
+          .expandShadowRoot(isExpandShadowRoot)
+          .build()
           .load(pageObjectType, LocatorBy.byCss(CONTAINER_CSS));
     }
   }

--- a/utam-core/src/test/java/utam/core/framework/base/ContainerElementTests.java
+++ b/utam-core/src/test/java/utam/core/framework/base/ContainerElementTests.java
@@ -48,20 +48,16 @@ public class ContainerElementTests {
     expectThrows(
         NoSuchElementException.class,
         () ->
-            new ContainerElementImpl(mock.getFactory(), elementMock, false)
+            new ContainerElementImpl(mock.getFactory(), elementMock)
+                .build()
                 .load(TestLoad.class, locator));
-    expectThrows(
-        NoSuchElementException.class,
-        () ->
-            new ContainerElementImpl(mock.getFactory(), elementMock, true)
-                .loadList(TestLoad.class, locator));
   }
 
   @Test
   public void testCreateWithElementFound() {
     MockUtilities mock = new MockUtilities();
     Element elementMock = mock.getElementAdapter();
-    ContainerElement element = new ContainerElementImpl(mock.getFactory(), elementMock, false);
+    ContainerElement element = new ContainerElementImpl(mock.getFactory(), elementMock).build();
     when(mock.getWebElementMock().findElements(By.cssSelector("css")))
         .thenReturn(Collections.singletonList(mock.getWebElementMock()));
     TestLoad testLoad = element.load(TestLoad.class, "css");
@@ -79,7 +75,8 @@ public class ContainerElementTests {
   public void testCreateWithElementFoundInShadow() {
     MockUtilities mock = new MockUtilities();
     Element elementMock = mock.getElementAdapter();
-    ContainerElement element = new ContainerElementImpl(mock.getFactory(), elementMock, true);
+    ContainerElement element =
+        new ContainerElementImpl(mock.getFactory(), elementMock).expandShadowRoot(true).build();
     mock.setShadowMock(mock.getWebElementMock(), "css");
     TestLoad testLoad = element.load(TestLoad.class, LocatorBy.byCss("css"));
     // driver > element >> By.cssSelector: css
@@ -90,7 +87,7 @@ public class ContainerElementTests {
   public void testSetScope() {
     MockUtilities mock = new MockUtilities();
     Element elementMock = mock.getElementAdapter();
-    ContainerElement element = new ContainerElementImpl(mock.getFactory(), elementMock, false);
+    ContainerElement element = new ContainerElementImpl(mock.getFactory(), elementMock);
     CompatiblePageObject compatiblePageObjectInsideContainer = new CompatiblePageObject();
     element.setScope(compatiblePageObjectInsideContainer);
     assertThat(
@@ -103,7 +100,7 @@ public class ContainerElementTests {
     NoSuchElementException e =
         expectThrows(
             NoSuchElementException.class,
-            () -> new ContainerElementImpl(mock.getFactory(), (Element) null, false));
+            () -> new ContainerElementImpl(mock.getFactory(), (Element) null));
     assertThat(e.getMessage(), containsString(NULL_SCOPE_ERR));
   }
 

--- a/utam-core/src/test/java/utam/core/framework/base/PageObjectTests.java
+++ b/utam-core/src/test/java/utam/core/framework/base/PageObjectTests.java
@@ -11,6 +11,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertThrows;
 import static utam.core.element.FindContext.Type.EXISTING;
@@ -20,6 +21,7 @@ import org.testng.annotations.Test;
 import utam.core.MockUtilities;
 import utam.core.driver.Document;
 import utam.core.driver.Navigation;
+import utam.core.framework.consumer.ContainerElement;
 import utam.core.framework.element.BasePageElement;
 import utam.core.selenium.element.LocatorBy;
 
@@ -81,9 +83,15 @@ public class PageObjectTests {
   @Test
   public void testInContainerMethod() {
     TestPageImpl testPage = new TestPageImpl();
-    assertThat(
-        testPage.container(testPage.getRootElement(), false),
-        is(instanceOf(ContainerElementImpl.class)));
+    ContainerElement element = testPage.container(testPage.getRootElement());
+    assertThat(element, is(instanceOf(ContainerElementImpl.class)));
+    assertThat(((ContainerElementImpl) element).findContext, nullValue());
+    element.expandShadowRoot(true);
+    element.nullable(true);
+    assertThat(((ContainerElementImpl) element).isNullable, is(true));
+    assertThat(((ContainerElementImpl) element).isExpandShadowRoot, is(true));
+    element.build();
+    assertThat(((ContainerElementImpl) element).findContext, notNullValue());
   }
 
   static class TestPageImpl extends BasePageObject {


### PR DESCRIPTION
Before change "nullable" was not supported, after the change if nullable is set to true, generated code will be
```java
return this.container(root).nullable(true).build().load(pageObjectType, locator);

// if expand shadow is also true
return this.container(root).expandShadow(true).nullable(true).build().load(pageObjectType, locator);
```

Docs update https://github.com/salesforce-experience-platform-emu/utam-docs/pull/1130