### PR TITLE
fix: update platform check for mobile android devices

### DIFF
--- a/utam-core/src/main/java/utam/core/framework/context/MobilePlatformType.java
+++ b/utam-core/src/main/java/utam/core/framework/context/MobilePlatformType.java
@@ -83,7 +83,7 @@ public enum MobilePlatformType implements Profile {
         return WEB;
       }
       Platform platform = ((AppiumDriver) driver).getCapabilities().getPlatformName();
-      if (platform == Platform.LINUX) {
+      if (platform == Platform.ANDROID) {
         return isTablet(driver) ? ANDROID_TABLET : ANDROID_PHONE;
       }
       if (platform == Platform.IOS) {

--- a/utam-core/src/test/java/utam/core/MockUtilities.java
+++ b/utam-core/src/test/java/utam/core/MockUtilities.java
@@ -88,7 +88,7 @@ public class MockUtilities {
     utamElement = createInstance(BasePageElement.class, elementAdapter, factory.getDriver());
     frameElement = createInstance(FrameElementImpl.class, elementAdapter, factory.getDriver());
     if (isMobileMock(driverType)) {
-      setMobilePlatform(Platform.LINUX);
+      setMobilePlatform(Platform.ANDROID);
     }
     TargetLocator targetLocator = mock(TargetLocator.class);
     when(webDriverMock.switchTo()).thenReturn(targetLocator);
@@ -120,12 +120,10 @@ public class MockUtilities {
 
   DriverAdapter setDriverAdapter(Class<? extends WebDriver> driverType) {
     WebDriver driver = getWebDriverMock();
-    if (driverType.equals(AppiumDriver.class)) {
-      setMobilePlatform(Platform.LINUX);
+    if (driverType.equals(AppiumDriver.class) || driverType.equals(AndroidDriver.class)) {
+      setMobilePlatform(Platform.ANDROID);
     } else if (driverType.equals(IOSDriver.class)) {
       setMobilePlatform(Platform.IOS);
-    } else if (driverType.equals(AndroidDriver.class)) {
-      setMobilePlatform(Platform.ANDROID);
     }
     return (DriverAdapter) WebDriverFactory.getAdapterMock(driver);
   }

--- a/utam-core/src/test/java/utam/core/framework/context/MobilePlatformTypeTests.java
+++ b/utam-core/src/test/java/utam/core/framework/context/MobilePlatformTypeTests.java
@@ -71,7 +71,7 @@ public class MobilePlatformTypeTests {
     when(driver.getCapabilities()).thenReturn(desiredCaps);
     desiredCaps.setCapability(DEVICE_NAME_NAME, DEVICE_NAME_VALUE_IPAD);
     assertThat(fromDriver(driver), is(IOS_TABLET));
-    desiredCaps.setPlatform(Platform.LINUX);
+    desiredCaps.setPlatform(Platform.ANDROID);
     desiredCaps.setCapability(DEVICE_SCREEN_SIZE_NAME, DEVICE_SCREEN_SIZE_VALUE_PHONE);
     desiredCaps.setCapability(DEVICE_SCREEN_DENSITY_NAME, DEVICE_SCREEN_DENSITY_VALUE_PHONE);
     when(driver.getCapabilities()).thenReturn(desiredCaps);

--- a/utam-core/src/test/java/utam/core/selenium/appium/MobileDriverAdapterTests.java
+++ b/utam-core/src/test/java/utam/core/selenium/appium/MobileDriverAdapterTests.java
@@ -406,7 +406,7 @@ public class MobileDriverAdapterTests {
     when(driver.getWindowHandles()).thenReturn(windowHandles);
     when(driver.getTitle()).thenReturn("").thenReturn(testWebViewTitle);
     when(contextSwitcher.getContext()).thenReturn(contextTracker.currentContext);
-    mock.setMobilePlatform(Platform.LINUX);
+    mock.setMobilePlatform(Platform.ANDROID);
     MobileDriverAdapter adapter = mock.getMobileDriverAdapter();
     assertThat(
         adapter.waitFor(() -> adapter.switchToWebView(testWebViewTitle)), is(sameInstance(driver)));


### PR DESCRIPTION
PR to fix the platform check for mobile android devices referring to paltform type as LINUX rather than ANDROID. Update the check.