### PR TITLE
fix: Correct class imports when custom element filter uses containsElement

### DIFF
--- a/utam-compiler/src/main/java/utam/compiler/representation/CustomElementMethod.java
+++ b/utam-compiler/src/main/java/utam/compiler/representation/CustomElementMethod.java
@@ -167,6 +167,9 @@ public abstract class CustomElementMethod implements PageObjectMethod {
       parametersTracker.setMethodParameters(locatorParameters);
       parametersTracker.setMethodParameters(applyParameters);
       parametersTracker.setMethodParameters(matcherParameters);
+      parametersTracker
+          .getMethodParameters()
+          .forEach(param -> ParameterUtils.setImport(classImports, param.getType()));
       String locationCode = getElementLocationCode(componentName, locatorParameters);
       String predicate =
           getPredicateCode(applyMethod, applyParameters, matcherType, matcherParameters);

--- a/utam-compiler/src/test/java/utam/compiler/representation/ElementMethodTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/representation/ElementMethodTests.java
@@ -350,4 +350,26 @@ public class ElementMethodTests {
     expected.addImpliedImportedTypes("utam.core.selenium.element.LocatorBy");
     PageObjectValidationTestHelper.validateMethod(method, expected);
   }
+
+  @Test
+  public void testFilterCustomElementWithContainsElementSelectorArgument() {
+    TranslationContext context =
+        new DeserializerUtilities().getContext("filter/customWithFilterContainsElement");
+    PageObjectMethod method = context.getMethod(ELEMENT_METHOD_NAME);
+    assertThat(method.getDeclaration().getCodeLine(), is(equalTo("Custom getTest(String value)")));
+    MethodInfo expected = new MethodInfo(ELEMENT_METHOD_NAME, "Custom");
+    expected.addParameter(new MethodParameterInfo("value", "String"));
+    expected.addParameter(
+        new MethodParameterInfo(
+            "LocatorBy.byCss(String.format(\"input[value='%s']\", value))", "LocatorBy"));
+    expected.addCodeLine("BasicElement root = this.getRootElement()");
+    expected.addCodeLine(
+        "return custom(root, this.test).build(Custom.class, elm ->"
+            + " Boolean.TRUE.equals(elm.containsElement(LocatorBy.byCss(String.format(\"input[value='%s']\","
+            + " value)))))");
+    expected.addImpliedImportedTypes("utam.custom.pageobjects.Custom");
+    expected.addImpliedImportedTypes("utam.core.element.BasicElement");
+    expected.addImpliedImportedTypes("utam.core.selenium.element.LocatorBy");
+    PageObjectValidationTestHelper.validateMethod(method, expected);
+  }
 }

--- a/utam-compiler/src/test/resources/filter/customWithFilterContainsElement.json
+++ b/utam-compiler/src/test/resources/filter/customWithFilterContainsElement.json
@@ -1,0 +1,34 @@
+{
+  "elements": [
+    {
+      "name": "test",
+      "public": true,
+      "type": "utam-custom/pageObjects/custom",
+      "selector": {
+        "css": "my-custom-element[with-attribute='attr-value']",
+        "returnAll": true
+      },
+      "filter": {
+        "apply": "containsElement",
+        "args": [
+          {
+            "type": "locator",
+            "value": {
+              "css": "input[value='%s']",
+              "args": [
+                {
+                  "name": "value",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ],
+        "findFirst": true,
+        "matcher": {
+          "type": "isTrue"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Previously, if a custom element (one with a `type` property referencing another PO type) had a filter that used `containsElement`, the `LocatorBy` reference was not being imported into the generated implementation class. This PR corrects that problem.