### PR TITLE
fix: prevent undesirable coercion of JSON values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <selenium.version>4.21.0</selenium.version>
         <appium.version>9.2.2</appium.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <jackson.version>2.16.0</jackson.version>
+        <jackson.version>2.18.4</jackson.version>
         <google.java.format.version>1.19.1</google.java.format.version>
         <picocli-version>4.7.5</picocli-version>
         <testng.version>7.8.0</testng.version>

--- a/utam-compiler/src/main/java/utam/compiler/grammar/JsonDeserializer.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/JsonDeserializer.java
@@ -24,7 +24,10 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.type.LogicalType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -86,6 +89,9 @@ public final class JsonDeserializer
     mapper.disable(ALLOW_COMMENTS);
     mapper.enable(ACCEPT_SINGLE_VALUE_AS_ARRAY);
     mapper.enable(STRICT_DUPLICATE_DETECTION);
+    mapper
+        .coercionConfigFor(LogicalType.Boolean)
+        .setCoercion(CoercionInputShape.String, CoercionAction.Fail);
     return mapper;
   }
 

--- a/utam-compiler/src/main/java/utam/compiler/grammar/UtamSelector.java
+++ b/utam-compiler/src/main/java/utam/compiler/grammar/UtamSelector.java
@@ -8,6 +8,7 @@
 package utam.compiler.grammar;
 
 import static utam.compiler.diagnostics.ValidationUtilities.VALIDATION;
+import static utam.compiler.grammar.JsonDeserializer.isEmptyNode;
 import static utam.compiler.grammar.JsonDeserializer.readNode;
 import static utam.core.element.Locator.SELECTOR_INTEGER_PARAMETER;
 import static utam.core.element.Locator.SELECTOR_STRING_PARAMETER;
@@ -84,6 +85,9 @@ class UtamSelector extends UtamRootSelector {
    */
   static UtamSelector processSelectorNode(JsonNode node, String elementName) {
     String parserContext = String.format("element \"%s\"", elementName);
+    if (!isEmptyNode(node) && !node.isObject()) {
+      throw new UtamCompilationError(VALIDATION.getErrorMessage(1000, parserContext));
+    }
     UtamSelector selector =
         readNode(node, UtamSelector.class, VALIDATION.getErrorMessage(1000, parserContext));
     if (selector != null) {

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamElementBasicTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamElementBasicTests.java
@@ -57,6 +57,28 @@ public class UtamElementBasicTests {
         containsString("error 302: element \"test\" filter: filter can only be set for list"));
   }
 
+  /** The validateSimpleElement method with string nullable type should throw */
+  @Test
+  public void testBasicElementInvalidNullableTypeThrows() {
+    UtamError e = expectThrows(UtamCompilationError.class, () -> getContext("nullableWrongType"));
+    assertThat(
+        e.getMessage(),
+        containsString(
+            "error 200: root elements: incorrect format of elements \n"
+                + "Cannot coerce String value (\"true\") to `java.lang.Boolean` value"));
+  }
+
+  /** The validateSimpleElement method with string public type should throw */
+  @Test
+  public void testBasicElementInvalidPublicTypeThrows() {
+    UtamError e = expectThrows(UtamCompilationError.class, () -> getContext("publicWrongType"));
+    assertThat(
+        e.getMessage(),
+        containsString(
+            "error 200: root elements: incorrect format of elements \n"
+                + "Cannot coerce String value (\"true\") to `java.lang.Boolean` value"));
+  }
+
   @Test
   public void testEmptyNestedElementsThrows() {
     UtamError e = expectThrows(UtamError.class, () -> getContext("emptyNestedElementsArray"));

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamElementWaitTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamElementWaitTests.java
@@ -117,6 +117,6 @@ public class UtamElementWaitTests {
         e.getMessage(),
         containsString(
             "error 200: root elements: incorrect format of elements \n"
-                + "Cannot deserialize value of type `java.lang.Boolean` from String \"string\""));
+                + "Cannot coerce String value (\"true\") to `java.lang.Boolean` value"));
   }
 }

--- a/utam-compiler/src/test/java/utam/compiler/grammar/UtamSelectorTests.java
+++ b/utam-compiler/src/test/java/utam/compiler/grammar/UtamSelectorTests.java
@@ -108,6 +108,14 @@ public class UtamSelectorTests {
   }
 
   @Test
+  public void testReturnAllWrongArgTypeProvided() {
+    Exception e = expectCompilerErrorFromFile("selectorReturnAllWrong");
+    assertThat(
+        e.getMessage(),
+        containsString("error 1000: element \"test\": format of selector is incorrect;"));
+  }
+
+  @Test
   public void testGetBuilderString() {
     final String prefix = LocatorBy.class.getSimpleName();
 

--- a/utam-compiler/src/test/resources/validate/basic_element/nullableWrongType.json
+++ b/utam-compiler/src/test/resources/validate/basic_element/nullableWrongType.json
@@ -5,7 +5,7 @@
       "selector": {
         "css": "basicElement"
       },
-      "wait": "true"
+      "nullable": "true"
     }
   ]
 }

--- a/utam-compiler/src/test/resources/validate/basic_element/publicWrongType.json
+++ b/utam-compiler/src/test/resources/validate/basic_element/publicWrongType.json
@@ -5,7 +5,7 @@
       "selector": {
         "css": "basicElement"
       },
-      "wait": "true"
+      "public": "true"
     }
   ]
 }

--- a/utam-compiler/src/test/resources/validate/selector/selectorReturnAllWrong.json
+++ b/utam-compiler/src/test/resources/validate/selector/selectorReturnAllWrong.json
@@ -1,0 +1,11 @@
+{
+  "elements": [
+    {
+      "name": "test",
+      "selector": {
+        "css": "selector",
+        "returnAll": "true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The Jackson JSON serialization library will attempt to coerce JSON values to Java data types when it is inappropriate. This leads to element properties being incorrect for the UTAM JSON grammar. For example, `"public": "true"` will incorrectly be coerced into a boolean value, when it should throw an error.

Moreover, newer versions of Jackson (`2.16` and higher) will allow more liberal deserialization of properties that should have object values. This allows an invalid UTAM construct line `"selector": "some-selector"`, which should error, as the value of the `selector` property is expected to be an object, not a string value.

This change fixes both issues, correctly throwing errors in cases where the wrong type of a property has been authored into the UTAM PO JSON declarative description file.