### PR TITLE
fix: support Appium 2 W3C-prefixed capabilities in MobilePlatformType

### DIFF
--- a/utam-core/src/main/java/utam/core/framework/context/MobilePlatformType.java
+++ b/utam-core/src/main/java/utam/core/framework/context/MobilePlatformType.java
@@ -103,9 +103,22 @@ public enum MobilePlatformType implements Profile {
     return name().toLowerCase();
   }
 
+  /**
+   * Reads an Appium capability, supporting both the W3C-prefixed key ("appium:&lt;name&gt;") used
+   * by Appium 2 / Selenium 4 and the unprefixed legacy key. The prefixed key takes precedence.
+   *
+   * @param caps capabilities to read from
+   * @param name unprefixed capability name
+   * @return capability value, or null if neither key is present
+   */
+  private static Object getAppiumCapability(Capabilities caps, String name) {
+    Object value = caps.getCapability("appium:" + name);
+    return value != null ? value : caps.getCapability(name);
+  }
+
   private static boolean isIPad(WebDriver driver) {
     Capabilities caps = ((AppiumDriver) driver).getCapabilities();
-    Object deviceObject = caps.getCapability("deviceName");
+    Object deviceObject = getAppiumCapability(caps, "deviceName");
     if (deviceObject != null) {
       return deviceObject.toString().toLowerCase().contains("ipad");
     }
@@ -114,8 +127,8 @@ public enum MobilePlatformType implements Profile {
 
   private static boolean isTablet(WebDriver driver) {
     Capabilities caps = ((AppiumDriver) driver).getCapabilities();
-    Object deviceScreenSizeObject = caps.getCapability("deviceScreenSize");
-    Object deviceScreenDensityObject = caps.getCapability("deviceScreenDensity");
+    Object deviceScreenSizeObject = getAppiumCapability(caps, "deviceScreenSize");
+    Object deviceScreenDensityObject = getAppiumCapability(caps, "deviceScreenDensity");
 
     // For android, based on https://developer.android.com/training/multiscreen/screensizes
     // when device's dp is equal or bigger than 600, will be treated as tablet, otherwise will be

--- a/utam-core/src/main/java/utam/core/framework/context/MobilePlatformType.java
+++ b/utam-core/src/main/java/utam/core/framework/context/MobilePlatformType.java
@@ -116,13 +116,25 @@ public enum MobilePlatformType implements Profile {
     return value != null ? value : caps.getCapability(name);
   }
 
-  private static boolean isIPad(WebDriver driver) {
-    Capabilities caps = ((AppiumDriver) driver).getCapabilities();
-    Object deviceObject = getAppiumCapability(caps, "deviceName");
-    if (deviceObject != null) {
-      return deviceObject.toString().toLowerCase().contains("ipad");
+  // Capability keys that may carry a human-readable device model. On Sauce Labs RDC,
+  // "deviceName" is set to the device UDID and the model lives under "testobject_device" /
+  // "testobject_device_name"; BrowserStack / LambdaTest commonly use "device".
+  private static final String[] DEVICE_NAME_CAPS = {
+    "deviceName", "testobject_device_name", "testobject_device", "device"
+  };
+
+  private static boolean deviceMatches(Capabilities caps, String needle) {
+    for (String key : DEVICE_NAME_CAPS) {
+      Object value = getAppiumCapability(caps, key);
+      if (value != null && value.toString().toLowerCase().contains(needle)) {
+        return true;
+      }
     }
     return false;
+  }
+
+  private static boolean isIPad(WebDriver driver) {
+    return deviceMatches(((AppiumDriver) driver).getCapabilities(), "ipad");
   }
 
   private static boolean isTablet(WebDriver driver) {
@@ -140,6 +152,8 @@ public enum MobilePlatformType implements Profile {
               / Integer.parseInt(deviceScreenDensityObject.toString());
       return dp >= 600;
     }
-    return false;
+    // Fallback for cloud farms (Sauce RDC, BrowserStack) that don't expose
+    // deviceScreenSize / deviceScreenDensity: check device-name caps for "tablet".
+    return deviceMatches(caps, "tablet");
   }
 }

--- a/utam-core/src/test/java/utam/core/framework/context/MobilePlatformTypeTests.java
+++ b/utam-core/src/test/java/utam/core/framework/context/MobilePlatformTypeTests.java
@@ -107,6 +107,41 @@ public class MobilePlatformTypeTests {
   }
 
   @Test
+  public void testFromDriverWithSauceRdcCapabilities() {
+    // Sauce Labs RDC sets appium:deviceName to the device UDID; the model name lives in
+    // appium:testobject_device / appium:testobject_device_name.
+    AppiumDriver driver = mock(IOSDriver.class);
+    DesiredCapabilities desiredCaps = new DesiredCapabilities();
+    desiredCaps.setCapability("appium:deviceName", "00008101-00015DE61403001E");
+    desiredCaps.setCapability("appium:testobject_device", "iPad_Air_2022_sf_us");
+    desiredCaps.setCapability("appium:testobject_device_name", "iPad Air 2022 5th Gen");
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
+    assertThat(fromDriver(driver), is(IOS_TABLET));
+
+    // iPhone on Sauce RDC: testobject_* present but model contains "iPhone", not "iPad".
+    desiredCaps = new DesiredCapabilities();
+    desiredCaps.setCapability("appium:deviceName", "00008030-000C0DDA0A12802E");
+    desiredCaps.setCapability("appium:testobject_device_name", "iPhone 13");
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
+    assertThat(fromDriver(driver), is(IOS_PHONE));
+  }
+
+  @Test
+  public void testFromDriverWithDeviceNameFallbackForAndroidTablet() {
+    // Cloud farms that don't expose deviceScreenSize/Density should still resolve to
+    // ANDROID_TABLET when a device-name cap mentions "tablet".
+    AppiumDriver driver = mock(AndroidDriver.class);
+    DesiredCapabilities desiredCaps = new DesiredCapabilities();
+    desiredCaps.setCapability("appium:testobject_device_name", "Galaxy Tab S8");
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
+    assertThat(fromDriver(driver), is(ANDROID_PHONE));
+
+    desiredCaps.setCapability("appium:testobject_device_name", "Some Android Tablet");
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
+    assertThat(fromDriver(driver), is(ANDROID_TABLET));
+  }
+
+  @Test
   public void testGetActivePlatformProfile() {
     Profile profile = getActivePlatformProfile(mock(WebDriver.class));
     assertThat(profile.getName(), is(equalTo(PLATFORM_PROFILE_NAME)));

--- a/utam-core/src/test/java/utam/core/framework/context/MobilePlatformTypeTests.java
+++ b/utam-core/src/test/java/utam/core/framework/context/MobilePlatformTypeTests.java
@@ -91,6 +91,22 @@ public class MobilePlatformTypeTests {
   }
 
   @Test
+  public void testFromDriverWithAppiumPrefixedCapabilities() {
+    AppiumDriver driver = mock(IOSDriver.class);
+    DesiredCapabilities desiredCaps = new DesiredCapabilities();
+    desiredCaps.setCapability("appium:deviceName", "iPad");
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
+    assertThat(fromDriver(driver), is(IOS_TABLET));
+
+    driver = mock(AndroidDriver.class);
+    desiredCaps = new DesiredCapabilities();
+    desiredCaps.setCapability("appium:deviceScreenSize", "1200x1920");
+    desiredCaps.setCapability("appium:deviceScreenDensity", "320");
+    when(driver.getCapabilities()).thenReturn(desiredCaps);
+    assertThat(fromDriver(driver), is(ANDROID_TABLET));
+  }
+
+  @Test
   public void testGetActivePlatformProfile() {
     Profile profile = getActivePlatformProfile(mock(WebDriver.class));
     assertThat(profile.getName(), is(equalTo(PLATFORM_PROFILE_NAME)));


### PR DESCRIPTION
  ## Summary
  Fixes #241.

  `MobilePlatformType.fromDriver()` was reading capabilities with unprefixed keys (`deviceName`, `deviceScreenSize`, `deviceScreenDensity`). Under Appium 2 / Selenium 4, these capabilities live under the W3C namespace prefix (`appium:deviceName`, etc.), so the lookups returned `null` and the method always fell back to `ANDROID_PHONE` / `IOS_PHONE` — tablet profiles never activated, causing `NoSuchElementException` when phone selectors didn't match tablet layouts.

  ## Changes
  - Added private helper `getAppiumCapability(Capabilities, String)` in `MobilePlatformType` that tries `"appium:" + name` first and falls back to the unprefixed key, preserving backward compatibility.
  - Updated `isIPad` and `isTablet` to use the helper.
  - Added `testFromDriverWithAppiumPrefixedCapabilities` covering the `ANDROID_TABLET` and `IOS_TABLET` paths via prefixed keys.

  Scoped the helper to `MobilePlatformType` rather than a shared utility: the only production reads of `getCapability` that need the prefix fallback are the three in this enum. Other call sites are tests that
  
  ## Test plan
  - [x] `mvn -pl utam-core test -Dtest=MobilePlatformTypeTests` — 7/7 pass
  - [x] `mvn -pl utam-core test` — 383/383 pass, no regressions 
  - [ ] Reviewer to confirm against an actual Appium 2 setup if available

  ## Update — broaden device-name capability search

  End-to-end validation on Sauce Labs Real Device Cloud surfaced a second issue: even with W3C-prefix support, `appium:deviceName` on Sauce RDC is the device UDID, not a model. The human-readable model lives under `appium:testobject_device` / `appium:testobject_device_name` (Sauce); BrowserStack and LambdaTest commonly use `appium:device`.

  Caps from a real Sauce RDC iPad Air session:

  appium:deviceName              =
  appium:testobject_device       = iPad_Air_2022_
  appium:testobject_device_name  = iPad Air 2022 5th Gen

  This commit generalizes `isIPad()` to consult an ordered list of device-name caps via a `deviceMatches()` helper, and adds an analogous name-based fallback to `isTablet()` for Android cloud-farm sessions that don't expose `deviceScreenSize` / `deviceScreenDensity`.

  New tests cover Sauce RDC iPad (UDID in `deviceName`, model in `testobject_device_name`), Sauce RDC iPhone (negative case), and the Android-tablet name fallback.

  Refs #241 (follow-up comment).

  Demonstration:
<img width="511" height="21" alt="Screenshot 2026-05-20 at 11 35 42" src="https://github.com/user-attachments/assets/236fc6bc-f06d-464c-8f27-307795808b84" />

<img width="486" height="29" alt="Screenshot 2026-05-20 at 11 27 48" src="https://github.com/user-attachments/assets/ec2bdc95-e8f9-4d3f-8281-e3ed16b570f4" />